### PR TITLE
Resolved multiple warnings about changing state during render

### DIFF
--- a/licenses.txt
+++ b/licenses.txt
@@ -243,13 +243,6 @@
 │  ├─ url: https://demurgos.net
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@bcoe\v8-coverage
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@bcoe\v8-coverage\LICENSE.md
-├─ @cnakazawa/watch@1.0.4
-│  ├─ licenses: Apache-2.0
-│  ├─ repository: https://github.com/mikeal/watch
-│  ├─ publisher: Mikeal Rogers
-│  ├─ email: mikeal.rogers@gmail.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@cnakazawa\watch
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@cnakazawa\watch\LICENSE
 ├─ @dnncommunity/dnn-elements@0.12.1-beta.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/dnncommunity/dnn-elements
@@ -284,52 +277,52 @@
 │  ├─ publisher: Corey Farrell
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@istanbuljs\schema
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@istanbuljs\schema\LICENSE
-├─ @jest/console@26.6.2
+├─ @jest/console@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\console
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\console\LICENSE
-├─ @jest/core@26.6.3
+├─ @jest/core@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\core
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\core\LICENSE
-├─ @jest/environment@26.6.2
+├─ @jest/environment@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\environment
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\environment\LICENSE
-├─ @jest/fake-timers@26.6.2
+├─ @jest/fake-timers@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\fake-timers
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\fake-timers\LICENSE
-├─ @jest/globals@26.6.2
+├─ @jest/globals@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\globals
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\globals\LICENSE
-├─ @jest/reporters@26.6.2
+├─ @jest/reporters@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\reporters
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\reporters\LICENSE
-├─ @jest/source-map@26.6.2
+├─ @jest/source-map@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\source-map
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\source-map\LICENSE
-├─ @jest/test-result@26.6.2
+├─ @jest/test-result@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\test-result
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\test-result\LICENSE
-├─ @jest/test-sequencer@26.6.3
+├─ @jest/test-sequencer@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\test-sequencer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@jest\test-sequencer\LICENSE
-├─ @jest/transform@26.6.2
+├─ @jest/transform@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@jest\transform
@@ -359,7 +352,7 @@
 │  ├─ repository: https://github.com/sinonjs/commons
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@sinonjs\commons
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@sinonjs\commons\LICENSE
-├─ @sinonjs/fake-timers@6.0.1
+├─ @sinonjs/fake-timers@8.1.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/sinonjs/fake-timers
 │  ├─ publisher: Christian Johansen
@@ -439,11 +432,6 @@
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\node
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@types\node\LICENSE
-├─ @types/normalize-package-data@2.4.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\normalize-package-data
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@types\normalize-package-data\LICENSE
 ├─ @types/prettier@2.4.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -464,7 +452,7 @@
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\yargs-parser
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\@types\yargs-parser\LICENSE
-├─ @types/yargs@15.0.14
+├─ @types/yargs@16.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\@types\yargs
@@ -596,27 +584,6 @@
 │  ├─ repository: https://github.com/nodeca/argparse
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\argparse
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\argparse\LICENSE
-├─ arr-diff@4.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/arr-diff
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-diff
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\arr-diff\LICENSE
-├─ arr-flatten@1.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/arr-flatten
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-flatten
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\arr-flatten\LICENSE
-├─ arr-union@3.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/arr-union
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\arr-union
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\arr-union\LICENSE
 ├─ array-find-index@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/array-find-index
@@ -641,13 +608,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-union
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\array-union\license
-├─ array-unique@0.3.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/array-unique
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\array-unique
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\array-unique\LICENSE
 ├─ array.prototype.flatmap@1.2.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Array.prototype.flatMap
@@ -661,13 +621,6 @@
 │  ├─ repository: https://github.com/kriskowal/asap
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\asap
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\asap\LICENSE.md
-├─ assign-symbols@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/assign-symbols
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\assign-symbols
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\assign-symbols\LICENSE
 ├─ astral-regex@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kevva/astral-regex
@@ -683,15 +636,7 @@
 │  ├─ email: iam@alexindigo.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\asynckit
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\asynckit\LICENSE
-├─ atob@2.1.2
-│  ├─ licenses: (MIT OR Apache-2.0)
-│  ├─ repository: git://git.coolaj86.com/coolaj86/atob.js
-│  ├─ publisher: AJ ONeal
-│  ├─ email: coolaj86@gmail.com
-│  ├─ url: https://coolaj86.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\atob
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\atob\LICENSE
-├─ babel-jest@26.6.3
+├─ babel-jest@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-jest
@@ -702,7 +647,7 @@
 │  ├─ publisher: Thai Pangsakulyanont @dtinth
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-istanbul
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-istanbul\LICENSE
-├─ babel-plugin-jest-hoist@26.6.2
+├─ babel-plugin-jest-hoist@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-plugin-jest-hoist
@@ -714,7 +659,7 @@
 │  ├─ url: https://github.com/nicolo-ribaudo
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-preset-current-node-syntax
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\babel-preset-current-node-syntax\LICENSE
-├─ babel-preset-jest@26.6.2
+├─ babel-preset-jest@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\babel-preset-jest
@@ -734,13 +679,6 @@
 │  ├─ email: t.jameson.little@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\base64-js
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\base64-js\LICENSE
-├─ base@0.11.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/node-base/base
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\base
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\base\LICENSE
 ├─ bl@4.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/rvagg/bl
@@ -802,13 +740,6 @@
 │  ├─ url: https://feross.org
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\buffer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\buffer\LICENSE
-├─ cache-base@1.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/cache-base
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cache-base
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\cache-base\LICENSE
 ├─ call-bind@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/call-bind
@@ -840,13 +771,6 @@
 │  ├─ url: http://beneb.info
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\caniuse-lite
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\caniuse-lite\LICENSE
-├─ capture-exit@2.0.0
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/stefanpenner/capture-exit
-│  ├─ publisher: Stefan Penner
-│  ├─ email: stefan.penner@gmail.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\capture-exit
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\capture-exit\README.md
 ├─ chalk@4.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/chalk
@@ -867,7 +791,7 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\chownr
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\chownr\LICENSE
-├─ ci-info@2.0.0
+├─ ci-info@3.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/watson/ci-info
 │  ├─ publisher: Thomas Watson Steen
@@ -875,20 +799,13 @@
 │  ├─ url: https://twitter.com/wa7son
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ci-info
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\ci-info\LICENSE
-├─ cjs-module-lexer@0.6.0
+├─ cjs-module-lexer@1.2.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/guybedford/cjs-module-lexer
 │  ├─ publisher: Guy Bedford
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\cjs-module-lexer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\cjs-module-lexer\LICENSE
-├─ class-utils@0.3.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/class-utils
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\class-utils
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\class-utils\LICENSE
-├─ cliui@6.0.0
+├─ cliui@7.0.4
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/cliui
 │  ├─ publisher: Ben Coe
@@ -905,13 +822,6 @@
 │  ├─ repository: https://github.com/SimenB/collect-v8-coverage
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\collect-v8-coverage
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\collect-v8-coverage\LICENSE
-├─ collection-visit@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/collection-visit
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\collection-visit
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\collection-visit\LICENSE
 ├─ color-convert@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/Qix-/color-convert
@@ -934,11 +844,6 @@
 │  ├─ url: http://debuggable.com/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\combined-stream
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\combined-stream\License
-├─ component-emitter@1.3.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/component/emitter
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\component-emitter
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\component-emitter\LICENSE
 ├─ concat-map@0.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/substack/node-concat-map
@@ -955,13 +860,6 @@
 │  ├─ url: http://thlorenz.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\convert-source-map
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\convert-source-map\LICENSE
-├─ copy-descriptor@0.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/copy-descriptor
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\copy-descriptor
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\copy-descriptor\LICENSE
 ├─ cross-fetch@3.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lquixada/cross-fetch
@@ -1010,14 +908,6 @@
 │  ├─ email: sam@strongloop.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\debuglog
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\debuglog\LICENSE
-├─ decamelize@1.2.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/decamelize
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\decamelize
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\decamelize\license
 ├─ decimal.js@10.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/MikeMcl/decimal.js
@@ -1025,14 +915,6 @@
 │  ├─ email: M8ch88l@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\decimal.js
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\decimal.js\LICENCE.md
-├─ decode-uri-component@0.2.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/SamVerschueren/decode-uri-component
-│  ├─ publisher: Sam Verschueren
-│  ├─ email: sam.verschueren@gmail.com
-│  ├─ url: github.com/SamVerschueren
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\decode-uri-component
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\decode-uri-component\license
 ├─ dedent@0.7.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/dmnd/dedent
@@ -1060,13 +942,6 @@
 │  ├─ publisher: Jordan Harband
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\define-properties
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\define-properties\LICENSE
-├─ define-property@2.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/define-property
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\define-property
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\define-property\LICENSE
 ├─ delayed-stream@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/felixge/node-delayed-stream
@@ -1129,7 +1004,7 @@
 │  ├─ publisher: Kilian Valkhof
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\electron-to-chromium
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\electron-to-chromium\LICENSE
-├─ emittery@0.7.2
+├─ emittery@0.8.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/emittery
 │  ├─ publisher: Sindre Sorhus
@@ -1257,19 +1132,12 @@
 │  ├─ repository: https://github.com/estools/esutils
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\esutils
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\esutils\LICENSE.BSD
-├─ exec-sh@0.3.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/tsertkov/exec-sh
-│  ├─ publisher: Aleksandr Tsertkov
-│  ├─ email: tsertkov@gmail.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\exec-sh
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\exec-sh\LICENSE
-├─ execa@1.0.0
+├─ execa@5.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/execa
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
+│  ├─ url: https://sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\execa
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\execa\license
 ├─ exit@0.1.2
@@ -1279,32 +1147,11 @@
 │  ├─ url: http://benalman.com/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\exit
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\exit\LICENSE-MIT
-├─ expand-brackets@2.1.4
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/expand-brackets
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\expand-brackets
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\expand-brackets\LICENSE
-├─ expect@26.6.2
+├─ expect@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\expect
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\expect\LICENSE
-├─ extend-shallow@3.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/extend-shallow
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extend-shallow
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\extend-shallow\LICENSE
-├─ extglob@2.0.4
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/micromatch/extglob
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\extglob
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\extglob\LICENSE
 ├─ extract-zip@2.0.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/maxogden/extract-zip
@@ -1397,13 +1244,6 @@
 │  ├─ publisher: Andrea Giammarchi
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\flatted
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\flatted\LICENSE
-├─ for-in@1.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/for-in
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\for-in
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\for-in\LICENSE
 ├─ form-data@3.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/form-data/form-data
@@ -1412,13 +1252,6 @@
 │  ├─ url: http://debuggable.com/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\form-data
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\form-data\License
-├─ fragment-cache@0.2.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/fragment-cache
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\fragment-cache
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\fragment-cache\LICENSE
 ├─ fs-constants@1.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/fs-constants
@@ -1473,12 +1306,12 @@
 │  ├─ publisher: Corey Farrell
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-package-type
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\get-package-type\LICENSE
-├─ get-stream@4.1.0
+├─ get-stream@6.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/get-stream
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
+│  ├─ url: https://sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-stream
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\get-stream\license
 ├─ get-symbol-description@1.0.0
@@ -1488,13 +1321,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-symbol-description
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\get-symbol-description\LICENSE
-├─ get-value@2.0.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/get-value
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\get-value
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\get-value\LICENSE
 ├─ glob-parent@5.1.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/gulpjs/glob-parent
@@ -1532,14 +1358,6 @@
 │  ├─ repository: https://github.com/isaacs/node-graceful-fs
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\graceful-fs
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\graceful-fs\LICENSE
-├─ growly@1.3.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/theabraham/growly
-│  ├─ publisher: Ibrahim Al-Rajhi
-│  ├─ email: abrahamalrajhi@gmail.com
-│  ├─ url: http://ibrahimalrajhi.com/
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\growly
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\growly\README.md
 ├─ has-bigints@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/has-bigints
@@ -1571,20 +1389,6 @@
 │  ├─ url: http://ljharb.codes
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-tostringtag
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\has-tostringtag\LICENSE
-├─ has-value@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/has-value
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-value
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\has-value\LICENSE
-├─ has-values@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/has-values
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\has-values
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\has-values\LICENSE
 ├─ has@1.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/tarruda/has
@@ -1630,7 +1434,7 @@
 │  ├─ url: http://n8.io/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\https-proxy-agent
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\https-proxy-agent\README.md
-├─ human-signals@1.1.1
+├─ human-signals@2.1.0
 │  ├─ licenses: Apache-2.0
 │  ├─ repository: https://github.com/ehmicky/human-signals
 │  ├─ publisher: ehmicky
@@ -1703,13 +1507,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\internal-slot
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\internal-slot\LICENSE
-├─ is-accessor-descriptor@0.1.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-accessor-descriptor
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-accessor-descriptor
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-accessor-descriptor\LICENSE
 ├─ is-arrayish@0.2.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/qix-/node-is-arrayish
@@ -1731,14 +1528,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-boolean-object
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-boolean-object\LICENSE
-├─ is-buffer@1.1.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/feross/is-buffer
-│  ├─ publisher: Feross Aboukhadijeh
-│  ├─ email: feross@feross.org
-│  ├─ url: http://feross.org/
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-buffer
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-buffer\LICENSE
 ├─ is-callable@1.2.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-callable
@@ -1747,14 +1536,6 @@
 │  ├─ url: http://ljharb.codes
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-callable
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-callable\LICENSE
-├─ is-ci@2.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/watson/is-ci
-│  ├─ publisher: Thomas Watson Steen
-│  ├─ email: w@tson.dk
-│  ├─ url: https://twitter.com/wa7son
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-ci
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-ci\LICENSE
 ├─ is-core-module@2.8.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-core-module
@@ -1762,41 +1543,12 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-core-module
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-core-module\LICENSE
-├─ is-data-descriptor@0.1.4
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-data-descriptor
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-data-descriptor
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-data-descriptor\LICENSE
 ├─ is-date-object@1.0.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/is-date-object
 │  ├─ publisher: Jordan Harband
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-date-object
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-date-object\LICENSE
-├─ is-descriptor@0.1.6
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-descriptor
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-descriptor
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-descriptor\LICENSE
-├─ is-docker@2.2.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/is-docker
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-docker
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-docker\license
-├─ is-extendable@0.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-extendable
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-extendable
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-extendable\LICENSE
 ├─ is-extglob@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/jonschlinkert/is-extglob
@@ -1848,13 +1600,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-number
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-number\LICENSE
-├─ is-plain-object@2.0.4
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-plain-object
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-plain-object
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-plain-object\LICENSE
 ├─ is-potential-custom-element-name@1.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mathiasbynens/is-potential-custom-element-name
@@ -1877,12 +1622,12 @@
 │  ├─ url: http://ljharb.codes
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-shared-array-buffer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-shared-array-buffer\LICENSE
-├─ is-stream@1.1.0
+├─ is-stream@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/is-stream
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
+│  ├─ url: https://sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-stream
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-stream\license
 ├─ is-string@1.0.7
@@ -1914,29 +1659,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-weakref
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-weakref\LICENSE
-├─ is-windows@1.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/is-windows
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-windows
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-windows\LICENSE
-├─ is-wsl@2.2.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/is-wsl
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\is-wsl
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\is-wsl\license
-├─ isarray@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/juliangruber/isarray
-│  ├─ publisher: Julian Gruber
-│  ├─ email: mail@juliangruber.com
-│  ├─ url: http://juliangruber.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isarray
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\isarray\README.md
 ├─ isexe@2.0.0
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/isexe
@@ -1945,13 +1667,6 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isexe
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\isexe\LICENSE
-├─ isobject@3.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/isobject
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\isobject
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\isobject\LICENSE
 ├─ istanbul-lib-coverage@3.2.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
@@ -1959,7 +1674,7 @@
 │  ├─ email: kananthmail-github@yahoo.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-coverage
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-coverage\LICENSE
-├─ istanbul-lib-instrument@4.0.3
+├─ istanbul-lib-instrument@5.1.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
@@ -1980,14 +1695,14 @@
 │  ├─ email: kananthmail-github@yahoo.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-source-maps
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\istanbul-lib-source-maps\LICENSE
-├─ istanbul-reports@3.0.5
+├─ istanbul-reports@3.1.4
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/istanbuljs/istanbuljs
 │  ├─ publisher: Krishnan Anantheswaran
 │  ├─ email: kananthmail-github@yahoo.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\istanbul-reports
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\istanbul-reports\LICENSE
-├─ jest-changed-files@26.6.2
+├─ jest-changed-files@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-changed-files
@@ -1997,12 +1712,12 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-circus
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-circus\LICENSE
-├─ jest-cli@26.6.3
+├─ jest-cli@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-cli
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-cli\LICENSE
-├─ jest-config@26.6.3
+├─ jest-config@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-config
@@ -2012,24 +1727,24 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-diff
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-diff\LICENSE
-├─ jest-docblock@26.0.0
+├─ jest-docblock@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-docblock
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-docblock\LICENSE
-├─ jest-each@26.6.2
+├─ jest-each@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ publisher: Matt Phillips
 │  ├─ url: mattphillips
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-each
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-each\LICENSE
-├─ jest-environment-jsdom@26.6.2
+├─ jest-environment-jsdom@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-environment-jsdom
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-environment-jsdom\LICENSE
-├─ jest-environment-node@26.6.2
+├─ jest-environment-node@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-environment-node
@@ -2039,32 +1754,32 @@
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-get-type
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-get-type\LICENSE
-├─ jest-haste-map@26.6.2
+├─ jest-haste-map@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-haste-map
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-haste-map\LICENSE
-├─ jest-jasmine2@26.6.3
+├─ jest-jasmine2@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-jasmine2
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-jasmine2\LICENSE
-├─ jest-leak-detector@26.6.2
+├─ jest-leak-detector@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-leak-detector
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-leak-detector\LICENSE
-├─ jest-matcher-utils@26.6.2
+├─ jest-matcher-utils@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-matcher-utils
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-matcher-utils\LICENSE
-├─ jest-message-util@26.6.2
+├─ jest-message-util@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-message-util
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-message-util\LICENSE
-├─ jest-mock@26.6.2
+├─ jest-mock@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-mock
@@ -2074,57 +1789,57 @@
 │  ├─ repository: https://github.com/arcanis/jest-pnp-resolver
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-pnp-resolver
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-pnp-resolver\README.md
-├─ jest-regex-util@26.0.0
+├─ jest-regex-util@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-regex-util
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-regex-util\LICENSE
-├─ jest-resolve-dependencies@26.6.3
+├─ jest-resolve-dependencies@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-resolve-dependencies
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-resolve-dependencies\LICENSE
-├─ jest-resolve@26.6.2
+├─ jest-resolve@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-resolve
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-resolve\LICENSE
-├─ jest-runner@26.6.3
+├─ jest-runner@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-runner
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-runner\LICENSE
-├─ jest-runtime@26.6.3
+├─ jest-runtime@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-runtime
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-runtime\LICENSE
-├─ jest-serializer@26.6.2
+├─ jest-serializer@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-serializer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-serializer\LICENSE
-├─ jest-snapshot@26.6.2
+├─ jest-snapshot@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-snapshot
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-snapshot\LICENSE
-├─ jest-util@26.6.2
+├─ jest-util@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-util
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-util\LICENSE
-├─ jest-validate@26.6.2
+├─ jest-validate@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-validate
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-validate\LICENSE
-├─ jest-watcher@26.6.2
+├─ jest-watcher@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-watcher
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jest-watcher\LICENSE
-├─ jest-worker@26.6.2
+├─ jest-worker@27.5.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/facebook/jest
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jest-worker
@@ -2193,13 +1908,6 @@
 │  ├─ publisher: Ethan Cohen
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\jsx-ast-utils
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\jsx-ast-utils\LICENSE.md
-├─ kind-of@6.0.3
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/kind-of
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\kind-of
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\kind-of\LICENSE
 ├─ kleur@3.0.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lukeed/kleur
@@ -2296,20 +2004,6 @@
 │  ├─ email: n@daaku.org
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\makeerror
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\makeerror\license
-├─ map-cache@0.2.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/map-cache
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\map-cache
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\map-cache\LICENSE
-├─ map-visit@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/map-visit
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\map-visit
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\map-visit\LICENSE
 ├─ merge-stream@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/grncdr/merge-stream
@@ -2363,13 +2057,6 @@
 │  ├─ url: http://substack.net
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\minimist
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\minimist\LICENSE
-├─ mixin-deep@1.3.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/mixin-deep
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\mixin-deep
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\mixin-deep\LICENSE
 ├─ mkdirp-classic@0.5.3
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mafintosh/mkdirp-classic
@@ -2390,13 +2077,6 @@
 │  ├─ repository: https://github.com/zeit/ms
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ms
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\ms\license.md
-├─ nanomatch@1.2.13
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/micromatch/nanomatch
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nanomatch
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\nanomatch\LICENSE
 ├─ natural-compare@1.4.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/litejs/natural-compare-lite
@@ -2404,11 +2084,6 @@
 │  ├─ url: https://github.com/litejs/natural-compare-lite
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\natural-compare
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\natural-compare\README.md
-├─ nice-try@1.0.5
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/electerious/nice-try
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\nice-try
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\nice-try\LICENSE
 ├─ node-fetch@2.6.7
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/bitinn/node-fetch
@@ -2422,20 +2097,6 @@
 │  ├─ email: robert@broofa.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-int64
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\node-int64\LICENSE
-├─ node-modules-regexp@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jamestalmage/node-modules-regexp
-│  ├─ publisher: James Talmage
-│  ├─ email: james@talmage.io
-│  ├─ url: github.com/jamestalmage
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-modules-regexp
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\node-modules-regexp\license
-├─ node-notifier@8.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/mikaelbr/node-notifier
-│  ├─ publisher: Mikael Brevik
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\node-notifier
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\node-notifier\LICENSE
 ├─ node-releases@2.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chicoxyzzy/node-releases
@@ -2473,7 +2134,7 @@
 │  ├─ url: https://izs.me
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\npm-normalize-package-bin
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\npm-normalize-package-bin\LICENSE
-├─ npm-run-path@2.0.2
+├─ npm-run-path@4.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/npm-run-path
 │  ├─ publisher: Sindre Sorhus
@@ -2497,13 +2158,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-assign
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object-assign\license
-├─ object-copy@0.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/object-copy
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-copy
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object-copy\LICENSE
 ├─ object-inspect@1.12.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/inspect-js/object-inspect
@@ -2520,13 +2174,6 @@
 │  ├─ url: http://ljharb.codes
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-keys
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object-keys\LICENSE
-├─ object-visit@1.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/object-visit
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object-visit
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object-visit\LICENSE
 ├─ object.assign@4.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/object.assign
@@ -2553,13 +2200,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.hasown
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object.hasown\LICENSE
-├─ object.pick@1.3.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/object.pick
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\object.pick
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\object.pick\LICENSE
 ├─ object.values@1.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/Object.values
@@ -2614,22 +2254,6 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\osenv
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\osenv\LICENSE
-├─ p-each-series@2.2.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/p-each-series
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: https://sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-each-series
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\p-each-series\license
-├─ p-finally@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/p-finally
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\p-finally
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\p-finally\license
 ├─ p-limit@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/p-limit
@@ -2678,13 +2302,6 @@
 │  ├─ url: https://github.com/inikulin
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\parse5
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\parse5\LICENSE
-├─ pascalcase@0.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/pascalcase
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pascalcase
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\pascalcase\LICENSE
 ├─ path-exists@4.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/path-exists
@@ -2744,9 +2361,9 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\picomatch
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\picomatch\LICENSE
-├─ pirates@4.0.1
+├─ pirates@4.0.5
 │  ├─ licenses: MIT
-│  ├─ repository: https://github.com/ariporad/pirates
+│  ├─ repository: https://github.com/danez/pirates
 │  ├─ publisher: Ari Porad
 │  ├─ email: ari@ariporad.com
 │  ├─ url: http://ariporad.com
@@ -2760,13 +2377,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\pkg-dir
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\pkg-dir\license
-├─ posix-character-classes@0.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/posix-character-classes
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\posix-character-classes
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\posix-character-classes\LICENSE
 ├─ prelude-ls@1.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/gkz/prelude-ls
@@ -2866,22 +2476,6 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-package-json
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\read-package-json\LICENSE
-├─ read-pkg-up@7.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/read-pkg-up
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-pkg-up
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\read-pkg-up\license
-├─ read-pkg@5.2.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/read-pkg
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\read-pkg
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\read-pkg\license
 ├─ readable-stream@3.6.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/nodejs/readable-stream
@@ -2895,13 +2489,6 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\readdir-scoped-modules
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\readdir-scoped-modules\LICENSE
-├─ regex-not@1.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/regex-not
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regex-not
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\regex-not\LICENSE
 ├─ regexp.prototype.flags@1.3.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/es-shims/RegExp.prototype.flags
@@ -2916,26 +2503,6 @@
 │  ├─ url: https://github.com/mysticatea
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\regexpp
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\regexpp\LICENSE
-├─ remove-trailing-separator@1.1.0
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/darsain/remove-trailing-separator
-│  ├─ publisher: darsain
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\remove-trailing-separator
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\remove-trailing-separator\license
-├─ repeat-element@1.1.4
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/repeat-element
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\repeat-element
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\repeat-element\LICENSE
-├─ repeat-string@1.6.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/repeat-string
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: http://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\repeat-string
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\repeat-string\LICENSE
 ├─ require-directory@2.1.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/troygoode/node-require-directory
@@ -2952,13 +2519,6 @@
 │  ├─ url: github.com/floatdrop
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\require-from-string
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\require-from-string\license
-├─ require-main-filename@2.0.0
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/yargs/require-main-filename
-│  ├─ publisher: Ben Coe
-│  ├─ email: ben@npmjs.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\require-main-filename
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\require-main-filename\LICENSE.txt
 ├─ resolve-cwd@3.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/resolve-cwd
@@ -2975,12 +2535,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve-from
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\resolve-from\license
-├─ resolve-url@0.2.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/lydell/resolve-url
-│  ├─ publisher: Simon Lydell
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve-url
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\resolve-url\LICENSE
 ├─ resolve.exports@1.1.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/lukeed/resolve.exports
@@ -2997,13 +2551,6 @@
 │  ├─ url: http://substack.net
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\resolve
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\resolve\LICENSE
-├─ ret@0.1.15
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/fent/ret.js
-│  ├─ publisher: Roly Fentanes
-│  ├─ url: https://github.com/fent
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\ret
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\ret\LICENSE
 ├─ reusify@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/mcollina/reusify
@@ -3019,12 +2566,6 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\rimraf
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\rimraf\LICENSE
-├─ rsvp@4.8.5
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/tildeio/rsvp.js
-│  ├─ publisher: Tilde, Inc. & Stefan Penner
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\rsvp
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\rsvp\LICENSE
 ├─ run-parallel@1.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/feross/run-parallel
@@ -3041,14 +2582,6 @@
 │  ├─ url: http://feross.org
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safe-buffer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\safe-buffer\LICENSE
-├─ safe-regex@1.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/substack/safe-regex
-│  ├─ publisher: James Halliday
-│  ├─ email: mail@substack.net
-│  ├─ url: http://substack.net
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safe-regex
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\safe-regex\LICENSE
 ├─ safer-buffer@2.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ChALkeR/safer-buffer
@@ -3057,12 +2590,6 @@
 │  ├─ url: https://github.com/ChALkeR
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\safer-buffer
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\safer-buffer\LICENSE
-├─ sane@4.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/amasad/sane
-│  ├─ publisher: amasad
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\sane
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\sane\README.md
 ├─ saxes@5.0.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/lddubeau/saxes
@@ -3075,20 +2602,6 @@
 │  ├─ repository: https://github.com/npm/node-semver
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\semver
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\semver\LICENSE
-├─ set-blocking@2.0.0
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/yargs/set-blocking
-│  ├─ publisher: Ben Coe
-│  ├─ email: ben@npmjs.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\set-blocking
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\set-blocking\LICENSE.txt
-├─ set-value@2.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/set-value
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\set-value
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\set-value\LICENSE
 ├─ shebang-command@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/kevva/shebang-command
@@ -3105,14 +2618,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shebang-regex
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\shebang-regex\license
-├─ shellwords@0.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jimmycuadra/shellwords
-│  ├─ publisher: Jimmy Cuadra
-│  ├─ email: jimmy@jimmycuadra.com
-│  ├─ url: http://jimmycuadra.com/
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\shellwords
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\shellwords\LICENSE
 ├─ side-channel@1.0.4
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ljharb/side-channel
@@ -3156,44 +2661,11 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\slide
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\slide\LICENSE
-├─ snapdragon-node@2.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/snapdragon-node
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon-node
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\snapdragon-node\LICENSE
-├─ snapdragon-util@3.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/snapdragon-util
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon-util
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\snapdragon-util\LICENSE
-├─ snapdragon@0.8.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/snapdragon
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\snapdragon
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\snapdragon\LICENSE
-├─ source-map-resolve@0.5.3
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/lydell/source-map-resolve
-│  ├─ publisher: Simon Lydell
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-resolve
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\source-map-resolve\LICENSE
 ├─ source-map-support@0.5.20
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/evanw/node-source-map-support
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-support
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\source-map-support\LICENSE.md
-├─ source-map-url@0.4.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/lydell/source-map-url
-│  ├─ publisher: Simon Lydell
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\source-map-url
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\source-map-url\LICENSE
 ├─ source-map@0.6.1
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/mozilla/source-map
@@ -3252,13 +2724,6 @@
 │  ├─ url: https://kemitchell.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\spdx-satisfies
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\spdx-satisfies\LICENSE
-├─ split-string@3.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/split-string
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\split-string
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\split-string\LICENSE
 ├─ sprintf-js@1.0.3
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/alexei/sprintf.js
@@ -3275,13 +2740,6 @@
 │  ├─ url: github.com/jamestalmage
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\stack-utils
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\stack-utils\license
-├─ static-extend@0.1.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/static-extend
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\static-extend
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\static-extend\LICENSE
 ├─ string-length@4.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/string-length
@@ -3340,14 +2798,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-bom
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\strip-bom\license
-├─ strip-eof@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/sindresorhus/strip-eof
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\strip-eof
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\strip-eof\license
 ├─ strip-final-newline@2.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/sindresorhus/strip-final-newline
@@ -3431,7 +2881,7 @@
 │  ├─ url: http://substack.net
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\text-table
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\text-table\LICENSE
-├─ throat@5.0.0
+├─ throat@6.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/ForbesLindesay/throat
 │  ├─ publisher: ForbesLindesay
@@ -3460,13 +2910,6 @@
 │  ├─ url: sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-fast-properties
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\to-fast-properties\license
-├─ to-object-path@0.3.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/to-object-path
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-object-path
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\to-object-path\LICENSE
 ├─ to-regex-range@5.0.1
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/micromatch/to-regex-range
@@ -3474,13 +2917,6 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-regex-range
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\to-regex-range\LICENSE
-├─ to-regex@3.0.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/to-regex
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\to-regex
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\to-regex\LICENSE
 ├─ tough-cookie@4.0.0
 │  ├─ licenses: BSD-3-Clause
 │  ├─ repository: https://github.com/salesforce/tough-cookie
@@ -3529,14 +2965,6 @@
 │  ├─ url: http://alogicalparadox.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-detect
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\type-detect\LICENSE
-├─ type-fest@0.8.1
-│  ├─ licenses: (MIT OR CC0-1.0)
-│  ├─ repository: https://github.com/sindresorhus/type-fest
-│  ├─ publisher: Sindre Sorhus
-│  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\type-fest
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\type-fest\license
 ├─ typedarray-to-buffer@3.1.5
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/feross/typedarray-to-buffer
@@ -3571,13 +2999,6 @@
 │  ├─ email: jan@lagomorph.de
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unbzip2-stream
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\unbzip2-stream\LICENSE
-├─ union-value@1.0.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/union-value
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\union-value
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\union-value\LICENSE
 ├─ universalify@0.1.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/RyanZim/universalify
@@ -3585,13 +3006,6 @@
 │  ├─ email: opensrc@ryanzim.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\universalify
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\universalify\LICENSE
-├─ unset-value@1.0.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/unset-value
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\unset-value
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\unset-value\LICENSE
 ├─ uri-js@4.4.1
 │  ├─ licenses: BSD-2-Clause
 │  ├─ repository: https://github.com/garycourt/uri-js
@@ -3599,19 +3013,6 @@
 │  ├─ email: gary.court@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uri-js
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\uri-js\LICENSE
-├─ urix@0.1.0
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/lydell/urix
-│  ├─ publisher: Simon Lydell
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\urix
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\urix\LICENSE
-├─ use@3.1.1
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/jonschlinkert/use
-│  ├─ publisher: Jon Schlinkert
-│  ├─ url: https://github.com/jonschlinkert
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\use
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\use\LICENSE
 ├─ util-deprecate@1.0.2
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/TooTallNate/util-deprecate
@@ -3625,11 +3026,6 @@
 │  ├─ repository: https://github.com/isaacs/util-extend
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\util-extend
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\util-extend\LICENSE
-├─ uuid@8.3.2
-│  ├─ licenses: MIT
-│  ├─ repository: https://github.com/uuidjs/uuid
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\uuid
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\uuid\LICENSE.md
 ├─ v8-compile-cache@2.3.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/zertosh/v8-compile-cache
@@ -3637,7 +3033,7 @@
 │  ├─ email: zertosh@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\v8-compile-cache
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\v8-compile-cache\LICENSE
-├─ v8-to-istanbul@7.1.2
+├─ v8-to-istanbul@8.1.1
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/istanbuljs/v8-to-istanbul
 │  ├─ publisher: Ben Coe
@@ -3709,12 +3105,6 @@
 │  ├─ email: ljharb@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\which-boxed-primitive
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\which-boxed-primitive\LICENSE
-├─ which-module@2.0.0
-│  ├─ licenses: ISC
-│  ├─ repository: https://github.com/nexdrew/which-module
-│  ├─ publisher: nexdrew
-│  ├─ path: D:\dnn-elements\dnn-elements\node_modules\which-module
-│  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\which-module\LICENSE
 ├─ which@2.0.2
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/isaacs/node-which
@@ -3730,12 +3120,12 @@
 │  ├─ url: https://github.com/jonschlinkert
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\word-wrap
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\word-wrap\LICENSE
-├─ wrap-ansi@6.2.0
+├─ wrap-ansi@7.0.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/chalk/wrap-ansi
 │  ├─ publisher: Sindre Sorhus
 │  ├─ email: sindresorhus@gmail.com
-│  ├─ url: sindresorhus.com
+│  ├─ url: https://sindresorhus.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\wrap-ansi
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\wrap-ansi\license
 ├─ wrappy@1.0.2
@@ -3777,11 +3167,11 @@
 │  ├─ email: ldd@lddubeau.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\xmlchars
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\xmlchars\LICENSE
-├─ y18n@4.0.3
+├─ y18n@5.0.8
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/y18n
 │  ├─ publisher: Ben Coe
-│  ├─ email: ben@npmjs.com
+│  ├─ email: bencoe@gmail.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\y18n
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\y18n\LICENSE
 ├─ yallist@4.0.0
@@ -3792,14 +3182,14 @@
 │  ├─ url: http://blog.izs.me/
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yallist
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\yallist\LICENSE
-├─ yargs-parser@18.1.3
+├─ yargs-parser@20.2.9
 │  ├─ licenses: ISC
 │  ├─ repository: https://github.com/yargs/yargs-parser
 │  ├─ publisher: Ben Coe
 │  ├─ email: ben@npmjs.com
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yargs-parser
 │  └─ licenseFile: D:\dnn-elements\dnn-elements\node_modules\yargs-parser\LICENSE.txt
-├─ yargs@15.4.1
+├─ yargs@16.2.0
 │  ├─ licenses: MIT
 │  ├─ repository: https://github.com/yargs/yargs
 │  ├─ path: D:\dnn-elements\dnn-elements\node_modules\yargs

--- a/src/components/dnn-image-cropper/dnn-image-cropper.tsx
+++ b/src/components/dnn-image-cropper/dnn-image-cropper.tsx
@@ -61,7 +61,9 @@ export class DnnImageCropper {
   private imageTooSmallModal!: HTMLDnnModalElement;
 
   componentDidLoad() {
-    this.setView("noPictureView");
+    requestAnimationFrame(() => {
+      this.setView("noPictureView");
+    })
   }
 
   private setView(newView: IComponentInterfaces["View"]){

--- a/src/components/dnn-tabs/dnn-tabs.tsx
+++ b/src/components/dnn-tabs/dnn-tabs.tsx
@@ -12,8 +12,10 @@ export class DnnTabs {
     @State() selectedTabTitle: string = "";
 
     componentDidLoad(){
-        this.updateTitles();
-        this.showFirstTab();
+        requestAnimationFrame(() => {
+            this.updateTitles();
+            this.showFirstTab();
+        });
     }
 
     private getTabs() {

--- a/src/components/dnn-treeview-item/dnn-treeview-item.tsx
+++ b/src/components/dnn-treeview-item/dnn-treeview-item.tsx
@@ -20,18 +20,20 @@ export class DnnTreeviewItem {
   private collapsible!: HTMLDnnCollapsibleElement;
 
   componentDidLoad() {
-    const children = this.childrenElement.children[0] as HTMLSlotElement;
-    const count = children.assignedElements().length
-    if (count > 0){
-      this.hasChildren = true;
-    }
-    if (this.expanded){
-      this.expander.classList.add("expanded");
-      this.collapsible.expanded = false;
-      setTimeout(() => {
-        this.collapsible.expanded = true;
-      }, 300);
-    }
+    requestAnimationFrame(() => {
+      const children = this.childrenElement.children[0] as HTMLSlotElement;
+      const count = children.assignedElements().length
+      if (count > 0){
+        this.hasChildren = true;
+      }
+      if (this.expanded){
+        this.expander.classList.add("expanded");
+        this.collapsible.expanded = false;
+        setTimeout(() => {
+          this.collapsible.expanded = true;
+        }, 300);
+      }
+    });
   }
 
   private toggleCollapse(): void {

--- a/src/components/dnn-vertical-splitview/dnn-vertical-splitview.tsx
+++ b/src/components/dnn-vertical-splitview/dnn-vertical-splitview.tsx
@@ -54,10 +54,12 @@ export class DnnVerticalSplitview {
   @Element() element : HTMLDnnVerticalSplitviewElement;
   
   componentDidLoad() {
-    const fullWidth = this.element.getBoundingClientRect().width;
-    this.leftWidth = fullWidth * this.splitWidthPercentage / 100;
-    this.rightWidth = fullWidth - this.leftWidth;
-    this.widthChanged.emit(this.splitWidthPercentage);
+    requestAnimationFrame(() => {
+      const fullWidth = this.element.getBoundingClientRect().width;
+      this.leftWidth = fullWidth * this.splitWidthPercentage / 100;
+      this.rightWidth = fullWidth - this.leftWidth;
+      this.widthChanged.emit(this.splitWidthPercentage);
+    });
   }
   
   private previousTouch: Touch;


### PR DESCRIPTION
A warning shows whenever a state that triggers a re-render happens as it is usually something that should be done before rendering and an extra render can be avoided by moving it to another lifecycle event. However in some cases it does make sense to re-render on purpose. The way to avoid the warning is to wrap the method in a requestAnimationFrame promise so that the state changes when we are sure the initial rendering is totally complete. It does not change much as it still re-renders but it kinda declares that it was on purpose and we know what we are doing. This way the warning goes away.