### PR TITLE
Build es5 components for production

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -19,5 +19,6 @@ export const config: Config = {
   plugins: [
     sass(),
   ],
-  sourceMap: true
+  sourceMap: true,
+  buildEs5: "prod",
 };


### PR DESCRIPTION
To be used in a wider range of scenarios this will also emit es5 packages but in production builds only so to not slow down development.

Closes #455 