### PR TITLE
Resolved collapsible nesting issues

### DIFF
--- a/src/components/dnn-collapsible/dnn-collapsible.scss
+++ b/src/components/dnn-collapsible/dnn-collapsible.scss
@@ -1,8 +1,8 @@
 :host {
   display: block;
-  #container{
-    height:0;
-    overflow: hidden;
-    transition: height 300ms ease-in-out;
-  }
+}
+#container{
+  max-height:0;
+  overflow: hidden;
+  transition: max-height 300ms ease-in-out;
 }

--- a/src/components/dnn-collapsible/dnn-collapsible.tsx
+++ b/src/components/dnn-collapsible/dnn-collapsible.tsx
@@ -1,5 +1,4 @@
-import { Component, Host, h, Prop, Element, Watch, State, Method, Event, EventEmitter, Listen } from '@stencil/core';
-import { Debounce } from '../../utilities/debounce';
+import { Component, Host, h, Prop, Element, Event, EventEmitter, Watch, Listen, Method } from '@stencil/core';
 
 @Component({
   tag: "dnn-collapsible",
@@ -16,99 +15,77 @@ export class DnnCollapsible {
   /** Defines the transition time in ms, defaults to 100ms */
   @Prop() transitionDuration?: number = 150;
 
-  @State() animating: boolean = false;
+  /** Fires whenever the collapsible height has changed */
+  @Event({bubbles: true, composed: true}) dnnCollapsibleHeightChanged: EventEmitter<void>;
 
-  @Watch("expanded")
-  handleExpandedChanged(newValue: boolean){
-    this.animating = true;
+  @Listen("dnnCollapsibleHeightChanged", {target: "body"})
+  handleHeightChanged(){
     requestAnimationFrame(() => {
-      const container = this.el.shadowRoot.querySelector("#container") as HTMLDivElement;
-      if (newValue){
-        container.style.height = container.scrollHeight + "px";
-      }
-      else{
-        container.style.height = "0px";
-      }
-    });
-    
-    requestAnimationFrame(() => {
-      this.animating = false;
-      this.dnnCollapsibleHeightChanged.emit();
-    });
+      console.log(this.el, "listened");
+      this.updateSize();
+    })
   }
 
-  /** Updates the component height, use to update after a slot content changes. */
-  @Debounce()
+  /**
+   * Updates the component height, use to update after a slot content changes.
+   */
   @Method()
   async updateSize() {
-    this.updateComponentSize();
-  }
-
-  private updateComponentSize(){
     if (this.expanded){
-      this.animating = true;
-      requestAnimationFrame(() => {
-        const container = this.el.shadowRoot.querySelector("#container") as HTMLDivElement;
-        let newHeight = 0;
-        container.querySelector('slot').assignedElements().forEach(node => {
-          newHeight += node.scrollHeight;
+        requestAnimationFrame(() => {
+          console.log(this.el, "is expanded and is now updating its size");
+          this.container.style.maxHeight = `${this.container.scrollHeight}px`;
         });
-        container.style.height = newHeight + "px";
-      });
+        setTimeout(() => {
+          this.container.style.maxHeight = "none";
+        }, this.transitionDuration);
     }
   }
-
-  /** Fires whenever the collapsible height has changed */
-  @Event() dnnCollapsibleHeightChanged: EventEmitter<void>;
-
-  @Listen('dnnCollapsibleHeightChanged')
-  handleOtherCollapsibleHeightChanged(){
-    setTimeout(() => {
-      this.updateComponentSize();
-    }, this.transitionDuration);
-  }
-
-  private mutationObserver: MutationObserver;
-
-  private handleMutation(mutationList){
-    mutationList.forEach(mutation => {
-      requestAnimationFrame(() => {
-        mutation.target.closest('dnn-collapsible').updateSize();
-      });
-    });
-  }
-
-  componentWillLoad() {
-    this.mutationObserver = new MutationObserver((mutationList) => {
-      this.handleMutation(mutationList);
-    });
-  }
-
-  componentDidLoad(){
-    const container = this.el.shadowRoot.querySelector('#container') as HTMLDivElement;
-    container.style.transitionDuration = this.transitionDuration + 'ms';
-
-    // Monitor for content changes and update own height
-    const childNodes = [this.el];
-    childNodes.forEach(element => {
-      this.mutationObserver.observe(element, {attributes: true, characterData: true, childList: true, subtree: true});
-    });
-
-    const slot = this.el.shadowRoot.querySelector('slot');
-    slot.addEventListener("slotchange", () => {
+  
+  @Watch("expanded")
+  handledExpandedChanged(expanded: boolean){
+    console.log(this.el, `expanded prop has changed to ${expanded}`);
+    if (expanded){
       this.updateSize();
-    });
+    }
+    else{
+      this.container.style.maxHeight = "0px";
+    }
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+        console.log(this.el, "firing the event now");
+        this.dnnCollapsibleHeightChanged.emit();
+      });
+    }, this.transitionDuration * 3);
+  }
+  
+  private observer = new MutationObserver(() => {
+    console.log(this.el, "observed a mutation and will uptade size.");
+    this.updateSize();
+  });
+  
+  componentDidLoad(){
+    var observerOptions: MutationObserverInit = {
+      attributes: true,
+      characterData: true,
+      childList: true,
+      subtree: true,
+    };
+    this.observer.observe(this.container, observerOptions);
+    const slot = this.container.querySelector("slot");
+    this.observer.observe(slot, observerOptions);
   }
 
   disconnectedCallback(){
-    this.mutationObserver.disconnect();
+    this.observer.disconnect();
   }
-  /*eslint-enable @stencil/own-methods-must-be-private */
+  
+  private container: HTMLDivElement;
 
   render() {
     return (
       <Host>
-        <div id="container">
+        <div id="container" class={this.expanded && "expanded"} ref={el => this.container = el}>
             <slot></slot>
         </div>
       </Host>

--- a/src/components/dnn-collapsible/dnn-collapsible.tsx
+++ b/src/components/dnn-collapsible/dnn-collapsible.tsx
@@ -18,10 +18,9 @@ export class DnnCollapsible {
   /** Fires whenever the collapsible height has changed */
   @Event({bubbles: true, composed: true}) dnnCollapsibleHeightChanged: EventEmitter<void>;
 
-  @Listen("dnnCollapsibleHeightChanged", {target: "body"})
+  @Listen("dnnCollapsibleHeightChanged")
   handleHeightChanged(){
     requestAnimationFrame(() => {
-      console.log(this.el, "listened");
       this.updateSize();
     })
   }
@@ -33,7 +32,6 @@ export class DnnCollapsible {
   async updateSize() {
     if (this.expanded){
         requestAnimationFrame(() => {
-          console.log(this.el, "is expanded and is now updating its size");
           this.container.style.maxHeight = `${this.container.scrollHeight}px`;
         });
         setTimeout(() => {
@@ -44,7 +42,6 @@ export class DnnCollapsible {
   
   @Watch("expanded")
   handledExpandedChanged(expanded: boolean){
-    console.log(this.el, `expanded prop has changed to ${expanded}`);
     if (expanded){
       this.updateSize();
     }
@@ -53,31 +50,9 @@ export class DnnCollapsible {
     }
     setTimeout(() => {
       requestAnimationFrame(() => {
-        console.log(this.el, "firing the event now");
         this.dnnCollapsibleHeightChanged.emit();
       });
-    }, this.transitionDuration * 3);
-  }
-  
-  private observer = new MutationObserver(() => {
-    console.log(this.el, "observed a mutation and will uptade size.");
-    this.updateSize();
-  });
-  
-  componentDidLoad(){
-    var observerOptions: MutationObserverInit = {
-      attributes: true,
-      characterData: true,
-      childList: true,
-      subtree: true,
-    };
-    this.observer.observe(this.container, observerOptions);
-    const slot = this.container.querySelector("slot");
-    this.observer.observe(slot, observerOptions);
-  }
-
-  disconnectedCallback(){
-    this.observer.disconnect();
+    }, this.transitionDuration);
   }
   
   private container: HTMLDivElement;

--- a/src/index.html
+++ b/src/index.html
@@ -185,7 +185,7 @@
           <dnn-chevron id="dnn-chevron1"></dnn-chevron>
           <strong>Collapsible Panel</strong>
         </div>
-        <dnn-collapsible id="dnn-collapsible1" transition-duration="1000">
+        <dnn-collapsible id="dnn-collapsible1" transition-duration="300">
           <div id="collapsible-slot-content" style="padding: 15px;">
             <h2>Details</h2>
             <p>
@@ -256,7 +256,7 @@
           else{
             slot.appendChild(content.cloneNode(true));
           }
-        }, 10000);
+        }, 1000);
       </script>
     </section>
 


### PR DESCRIPTION
This refactors the collapsible component to be more simple and fixes an issue with nesting collapsible in a certain way where parents would not update their size properly if the contents of slots are dynamically changed at runtime.

The behaviour here is that it will transition to the height of the knows content but afterwards will release the fixed size and just snap to the new content should it change dynamically. We win in usability here but have a small snap UI effect in some situations. I would like to improve this one day, but for now, this makes it more usable.