### PR TITLE
Add watch for expanded prop and handle accordingly

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -219,7 +219,7 @@ export namespace Components {
     }
     interface DnnTreeviewItem {
         /**
-          * Defines if the current node is expanded
+          * Defines if the current node is expanded.
          */
         "expanded": boolean;
     }
@@ -601,7 +601,7 @@ declare namespace LocalJSX {
     }
     interface DnnTreeviewItem {
         /**
-          * Defines if the current node is expanded
+          * Defines if the current node is expanded.
          */
         "expanded"?: boolean;
         /**

--- a/src/components/dnn-treeview-item/dnn-treeview-item.tsx
+++ b/src/components/dnn-treeview-item/dnn-treeview-item.tsx
@@ -29,10 +29,11 @@ export class DnnTreeviewItem {
     if (expanded) {
       this.expander.classList.add("expanded");
       this.collapsible.expanded = true;
-    } else {
-      this.expander.classList.remove("expanded");
-      this.collapsible.expanded = false;
+      return;
     }
+    
+    this.expander.classList.remove("expanded");
+    this.collapsible.expanded = false;
   }
       
   

--- a/src/components/dnn-treeview-item/dnn-treeview-item.tsx
+++ b/src/components/dnn-treeview-item/dnn-treeview-item.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Element, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop, State, Element, Event, EventEmitter, Watch } from '@stencil/core';
 
 @Component({
   tag: 'dnn-treeview-item',
@@ -11,8 +11,8 @@ export class DnnTreeviewItem {
 
   @Element() el!: HTMLDnnTreeviewItemElement;
   
-  /** Defines if the current node is expanded  */
-  @Prop({mutable: true}) expanded: boolean = false;
+  /** Defines if the current node is expanded.  */
+  @Prop({mutable: true, reflect: true}) expanded: boolean = false;
 
   /** Fires when the user expands a node. */
   @Event({bubbles: false}) userExpanded: EventEmitter<void>;
@@ -20,24 +20,35 @@ export class DnnTreeviewItem {
   /** Fires when the user collapses a node. */
   @Event({bubbles: false}) userCollapsed: EventEmitter<void>;
 
+  /** Manages state for whether or not item has children. */
   @State() hasChildren: boolean = false;
+
+  /** Watch expanded Prop */
+  @Watch('expanded')
+  watchExpanded(expanded: boolean) {
+    if (expanded) {
+      this.expander.classList.add("expanded");
+      this.collapsible.expanded = true;
+    } else {
+      this.expander.classList.remove("expanded");
+      this.collapsible.expanded = false;
+    }
+  }
+      
   
-  private childrenElement!: HTMLDivElement;
+  private childElement!: HTMLDivElement;
   private collapsible!: HTMLDnnCollapsibleElement;
 
   componentDidLoad() {
     requestAnimationFrame(() => {
-      const children = this.childrenElement.children[0] as HTMLSlotElement;
-      const count = children.assignedElements().length
+      const child = this.childElement.children[0] as HTMLSlotElement;
+      const count = child.assignedElements().length
       if (count > 0){
         this.hasChildren = true;
       }
       if (this.expanded){
         this.expander.classList.add("expanded");
-        this.collapsible.expanded = false;
-        setTimeout(() => {
-          this.collapsible.expanded = true;
-        }, 300);
+        this.collapsible.expanded = true;
       }
     });
   }
@@ -71,7 +82,7 @@ export class DnnTreeviewItem {
             <slot></slot>
           </div>
           <dnn-collapsible ref={el => this.collapsible = el} expanded={this.expanded}>
-            <div ref={el => this.childrenElement = el}>
+            <div ref={el => this.childElement = el}>
               <slot name="children"></slot>
             </div>
           </dnn-collapsible>


### PR DESCRIPTION
Now there is a mechanism for the consumer to manage the collapsing and expansion of treeview item nodes.  This PR adds a `Watch` on the `expanded` property and handles accordingly.