### PR TITLE
Resolve issue with initial expanded treeview item

### DIFF
--- a/src/components/dnn-treeview-item/dnn-treeview-item.tsx
+++ b/src/components/dnn-treeview-item/dnn-treeview-item.tsx
@@ -49,7 +49,10 @@ export class DnnTreeviewItem {
       }
       if (this.expanded){
         this.expander.classList.add("expanded");
-        this.collapsible.expanded = true;
+        this.collapsible.expanded = false;
+        setTimeout(() => {
+          this.collapsible.expanded = true;
+        }, 300);
       }
     });
   }


### PR DESCRIPTION
A `setTimeout` was removed previously that is evidently needed for the `ComponentDidLoad` event.  This ensures a treeview item that is initially expanded is handled properly.