### PR TITLE
Add story for `dnn-tab`

### DIFF
--- a/src/components/dnn-chevron/dnn-chevron.stories.ts
+++ b/src/components/dnn-chevron/dnn-chevron.stories.ts
@@ -13,10 +13,10 @@ export default {
         notes:  readme,
     },
     argTypes: {
-        'expandText': {
+        'expand-text': {
             control: 'text',
         },
-        'collapseText': {
+        'collapse-text': {
             control: 'text',
         },
         'expanded': {
@@ -28,7 +28,7 @@ export default {
 const Template = (args) =>
     html`
         <dnn-chevron
-            expandText=${ifDefined(args.expandText)}
+            expand-text=${ifDefined(args.expandText)}
             collapse-text=${ifDefined(args.collapseText)}
             ?expanded=${ifDefined(args.expanded)}>
         </dnn-chevron>

--- a/src/components/dnn-tab/dnn-tab.stories.ts
+++ b/src/components/dnn-tab/dnn-tab.stories.ts
@@ -1,0 +1,29 @@
+import { html } from "lit-html";
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { Meta } from "@storybook/web-components";
+import readme from './readme.md';
+
+export default {
+    title: 'Elements/Tab',
+    component: 'dnn-tab',
+    parameters: {
+        notes:  readme,
+    },
+    argTypes: {
+        'tab-title': {
+            control: 'text',
+        },
+    }
+} as Meta;
+
+const Template = (args) =>
+    html`
+        <dnn-tab
+            tab-title=${ifDefined(args.tabTitle)}>
+        </dnn-tab>
+    `;
+
+export const Tab = Template.bind({});
+Tab.args = {
+    tabTitle: 'My Tab',
+};


### PR DESCRIPTION
Resolves #513 

Also resolved a minor issue with `dnn-chevron` regarding dash casing for props.

One thing to note about this one is that it is intended for use with `dnn-tabs` and will not show the component on the `Canvas` or `Docs` (because by default it's `visible` state is `false`).

![image](https://user-images.githubusercontent.com/4568451/159140454-67507a2a-4bb1-4923-93c8-bd835c4785f9.png)
