### PR TITLE
Raised modal z-index

### DIFF
--- a/src/components/dnn-modal/dnn-modal.scss
+++ b/src/components/dnn-modal/dnn-modal.scss
@@ -10,7 +10,7 @@
     left:0;
     width: 100%;
     height: 100%;
-    z-index: 1;
+    z-index: 1002; // DNN default theme has menus on z-index 1001
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
In some situation using in DNN many surounding elements can have a z-index of 1000+ (menus, floats, other modal, etc.) So this raises the default modal overlay to z-index of 1002.

This is to fix https://github.com/dnnsoftware/Dnn.Platform/issues/5290