### PR TITLE
Fixed a few assets paths issues for monaco-editor

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -20,7 +20,7 @@
         "path": "node_modules\\@geometricpanda\\storybook-addon-badges",
         "licenseFile": "node_modules\\@geometricpanda\\storybook-addon-badges\\LICENCE.md"
     },
-    "@stencil/core@2.18.1": {
+    "@stencil/core@2.19.3": {
         "licenses": "MIT",
         "repository": "https://github.com/ionic-team/stencil",
         "publisher": "Ionic Team",
@@ -172,7 +172,7 @@
         "path": "node_modules\\lit-html",
         "licenseFile": "node_modules\\lit-html\\LICENSE"
     },
-    "monaco-editor@0.33.0": {
+    "monaco-editor@0.34.1": {
         "licenses": "MIT",
         "repository": "https://github.com/microsoft/monaco-editor",
         "publisher": "Microsoft Corporation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10270,9 +10270,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true,
       "funding": [
         {
@@ -34762,9 +34762,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001423",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz",
-      "integrity": "sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==",
+      "version": "1.0.30001436",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+      "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
       "dev": true
     },
     "capture-exit": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -195,6 +195,11 @@ export namespace Components {
          */
         "setFocus": () => Promise<void>;
         /**
+          * Sets a new editor value.
+          * @param newValue The new value to set.
+         */
+        "setValue": (newValue: string) => Promise<void>;
+        /**
           * Update code language editor
          */
         "updateLanguage": (languageId: string) => Promise<void>;

--- a/src/components/dnn-color-picker/readme.md
+++ b/src/components/dnn-color-picker/readme.md
@@ -5,6 +5,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Color Picker for Dnn
+
 ## Properties
 
 | Property         | Attribute          | Description                                                                                | Type     | Default    |

--- a/src/components/dnn-image-cropper/readme.md
+++ b/src/components/dnn-image-cropper/readme.md
@@ -5,6 +5,12 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Allows cropping an image in-browser with the option to enforce a specific final size.
+All computation happens in the browser and the final image is emmited
+in an event that has a data-url of the image.
+
 ## Properties
 
 | Property            | Attribute            | Description                                                                                                                                 | Type                                                                                                                                                | Default                                                                                                                                                                                                                                                                                                                                                                     |

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.scss
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.scss
@@ -1,5 +1,3 @@
-@import "~monaco-editor/min/vs/editor/editor.main.css";
-
 :host {
     /**
     * @prop --monaco-editor-width: width of the editor, default is 100%

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -1,4 +1,4 @@
-import {Component, ComponentInterface, Element, Event, EventEmitter, h, Host, Method, Prop, Watch} from '@stencil/core';
+import {Component, ComponentInterface, Element, Event, EventEmitter, getAssetPath, h, Host, Method, Prop, Watch} from '@stencil/core';
 import * as monaco from 'monaco-editor';
 import { editor } from 'monaco-editor';
 import {escapeCode, unescapeCode} from './utils/code.utils';
@@ -60,6 +60,12 @@ export class MonacoEditor implements ComponentInterface {
           return editorWorkerPath;
       }
     };
+
+    const editorGlobalCssPath = getAssetPath("/monaco-editor/editor/editor.main.css");
+    const link = document.createElement("link");
+    link.href = editorGlobalCssPath;
+    link.rel = "stylesheet";
+    document.head.appendChild(link);
   }
 
   componentDidLoad() {
@@ -112,6 +118,15 @@ export class MonacoEditor implements ComponentInterface {
   @Method()
   async getValue(){
     return Promise.resolve(escapeCode(this.editor?.getValue()));
+  }
+
+  /**
+   * Sets a new editor value.
+   * @param newValue The new value to set.
+   */
+  @Method()
+  async setValue(newValue: string){
+    this.editor?.setValue(unescapeCode(newValue));
   }
 
   private mergeOptions(): monaco.editor.IStandaloneEditorConstructionOptions {

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -62,10 +62,13 @@ export class MonacoEditor implements ComponentInterface {
     };
 
     const editorGlobalCssPath = getAssetPath("/monaco-editor/editor/editor.main.css");
-    const link = document.createElement("link");
-    link.href = editorGlobalCssPath;
-    link.rel = "stylesheet";
-    document.head.appendChild(link);
+    const existing = document.querySelector(`link[href="${editorGlobalCssPath}"]`);
+    if (existing === null) {
+      const link = document.createElement("link");
+      link.href = editorGlobalCssPath;
+      link.rel = "stylesheet";
+      document.head.appendChild(link);
+    }
   }
 
   componentDidLoad() {

--- a/src/components/dnn-tab/readme.md
+++ b/src/components/dnn-tab/readme.md
@@ -17,6 +17,10 @@
 <!-- Auto Generated Below -->
 
 
+## Overview
+
+Represents a single tab and must be used inside a dnn-tabs element.
+
 ## Properties
 
 | Property                | Attribute   | Description            | Type     | Default     |

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -90,7 +90,17 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-      esmLoaderPath: '../loader'
+      esmLoaderPath: '../loader',
+      copy: [
+        {
+          src: '../node_modules/monaco-editor/min/vs/editor/editor.main.css',
+          dest: 'monaco-editor/editor/editor.main.css'
+        },
+        {
+          src: '../node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf',
+          dest: 'monaco-editor/base/browser/ui/codicons/codicon/codicon.ttf'
+        },
+      ],
     },
     {
       type: 'docs-readme'
@@ -101,7 +111,17 @@ export const config: Config = {
     },
     {
       type: 'www',
-      serviceWorker: null // disable service workers
+      serviceWorker: null, // disable service workers
+      copy: [
+        {
+          src: '../node_modules/monaco-editor/min/vs/editor/editor.main.css',
+          dest: 'monaco-editor/editor/editor.main.css'
+        },
+        {
+          src: '../node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf',
+          dest: 'monaco-editor/base/browser/ui/codicons/codicon/codicon.ttf'
+        },
+      ],
     }
   ],
   plugins: [


### PR DESCRIPTION
This copies some assets needed on the page level and loads them in the page head if the editor is used on the page.

The monaco css also requires a font and it is expected to live in a very specific relative path so files need to be manually copied into specific folders.

It also looks like a full build was not run before the beta release, so some docs were not auto-generated on other components earlier.

Also I added a new method to allow consumers to change the code content after the component is already loaded.