### PR TITLE
More monaco fixes

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -605,6 +605,12 @@
             },
             {
               "kind": "method",
+              "name": "setValue",
+              "description": "Sets a new editor value.",
+              "signature": "setValue(newValue: string) => Promise<void>"
+            },
+            {
+              "kind": "method",
               "name": "updateLanguage",
               "description": "Update code language editor",
               "signature": "updateLanguage(languageId: string) => Promise<void>"

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.scss
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.scss
@@ -1,3 +1,5 @@
+@import '~monaco-editor/dev/vs/editor/editor.main.css';
+
 :host {
     /**
     * @prop --monaco-editor-width: width of the editor, default is 100%

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -2,7 +2,7 @@ import {Component, ComponentInterface, Element, Event, EventEmitter, h, Host, Me
 import * as monaco from 'monaco-editor';
 import { editor } from 'monaco-editor';
 import {escapeCode, unescapeCode} from './utils/code.utils';
-import { worker as  jsonWorker } from 'monaco-editor/esm/vs/language/json/json.worker.js?worker';
+import { worker as jsonWorker } from 'monaco-editor/esm/vs/language/json/json.worker.js?worker';
 import { worker as cssWorker } from 'monaco-editor/esm/vs/language/css/css.worker.js?worker';
 import { worker as htmlWorker } from 'monaco-editor/esm/vs/language/html/html.worker.js?worker';
 import { worker as tsWorker } from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker';

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -1,12 +1,12 @@
-import {Component, ComponentInterface, Element, Event, EventEmitter, getAssetPath, h, Host, Method, Prop, Watch} from '@stencil/core';
+import {Component, ComponentInterface, Element, Event, EventEmitter, h, Host, Method, Prop, Watch} from '@stencil/core';
 import * as monaco from 'monaco-editor';
 import { editor } from 'monaco-editor';
 import {escapeCode, unescapeCode} from './utils/code.utils';
-import { workerPath as  jsonWorkerPath } from 'monaco-editor/esm/vs/language/json/json.worker.js?worker';
-import { workerPath as cssWorkerPath } from 'monaco-editor/esm/vs/language/css/css.worker.js?worker';
-import { workerPath as htmlWorkerPath } from 'monaco-editor/esm/vs/language/html/html.worker.js?worker';
-import { workerPath as tsWorkerPath } from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker';
-import { workerPath as editorWorkerPath } from 'monaco-editor/esm/vs/editor/editor.worker.js?worker';
+import { worker as  jsonWorker } from 'monaco-editor/esm/vs/language/json/json.worker.js?worker';
+import { worker as cssWorker } from 'monaco-editor/esm/vs/language/css/css.worker.js?worker';
+import { worker as htmlWorker } from 'monaco-editor/esm/vs/language/html/html.worker.js?worker';
+import { worker as tsWorker } from 'monaco-editor/esm/vs/language/typescript/ts.worker.js?worker';
+import { worker as editorWorker } from 'monaco-editor/esm/vs/editor/editor.worker.js?worker';
 
 @Component({
   tag: 'dnn-monaco-editor',
@@ -23,13 +23,15 @@ export class MonacoEditor implements ComponentInterface {
   @Event() editorDidLoad: EventEmitter<void>;
 
   private editor: monaco.editor.IStandaloneCodeEditor;
-
-  private div!: HTMLDivElement;
+  private article!: HTMLElement;
+  private aria!: HTMLDivElement;
 
   private readonly defaultOptions: monaco.editor.IStandaloneEditorConstructionOptions = {
     automaticLayout: true,
     language: 'typescript',
     lineNumbers: "on",
+    fixedOverflowWidgets: true,
+    useShadowDOM: true,
     minimap: {
       enabled: true
     },
@@ -44,37 +46,35 @@ export class MonacoEditor implements ComponentInterface {
 
   connectedCallback() {
     (self as any).MonacoEnvironment = {
-      getWorkerUrl: function (_moduleId, label) {
+      getWorker: function (_moduleId, label) {
           if (label === 'json') {
-            return jsonWorkerPath;
+            return jsonWorker;
           }
           if (label === 'css' || label === 'scss' || label === 'less') {
-            return cssWorkerPath;
+            return cssWorker;
           }
           if (label === 'html' || label === 'handlebars' || label === 'razor') {
-            return htmlWorkerPath;
+            return htmlWorker;
           }
           if (label === 'typescript' || label === 'javascript') {
-            return tsWorkerPath;
+            return tsWorker;
           }
-          return editorWorkerPath;
+          return editorWorker;
       }
     };
 
-    const editorGlobalCssPath = getAssetPath("/monaco-editor/editor/editor.main.css");
-    const existing = document.querySelector(`link[href="${editorGlobalCssPath}"]`);
-    if (existing === null) {
-      const link = document.createElement("link");
-      link.href = editorGlobalCssPath;
-      link.rel = "stylesheet";
-      document.head.appendChild(link);
-    }
+    let path = import.meta.url.substring(0, import.meta.url.lastIndexOf('/'));
+    path = `${path}/assets/monaco-editor/codicon.ttf`;
+
+    const style = document.createElement('style');
+    style.innerText = `@font-face { font-family: 'codicon'; src: url('${path}') format('truetype');}`;
+    document.head.appendChild(style);
   }
 
   componentDidLoad() {
     const slottedCode: HTMLElement = this.el.querySelector(':scope > *:first-of-type');
 
-    this.editor = monaco.editor.create(this.div, {
+    this.editor = monaco.editor.create(this.article, {
       value: unescapeCode(slottedCode?.innerHTML.trim() || ''),
       ...this.mergeOptions()
     });
@@ -135,6 +135,7 @@ export class MonacoEditor implements ComponentInterface {
   private mergeOptions(): monaco.editor.IStandaloneEditorConstructionOptions {
     return {
       ...this.defaultOptions,
+      ariaContainerElement: this.aria,
       ...(this.options || {})
     };
   }
@@ -142,7 +143,8 @@ export class MonacoEditor implements ComponentInterface {
   render() {
     return (
       <Host>
-        <article ref={(el) => (this.div = el as HTMLDivElement)}></article>
+          <article ref={el => this.article = el}></article>
+          <div style={{display: 'none'}} ref={el => this.aria = el}></div>
       </Host>
     );
   }

--- a/src/components/dnn-monaco-editor/readme.md
+++ b/src/components/dnn-monaco-editor/readme.md
@@ -41,6 +41,16 @@ Type: `Promise<void>`
 
 
 
+### `setValue(newValue: string) => Promise<void>`
+
+Sets a new editor value.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `updateLanguage(languageId: string) => Promise<void>`
 
 Update code language editor

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -93,12 +93,8 @@ export const config: Config = {
       esmLoaderPath: '../loader',
       copy: [
         {
-          src: '../node_modules/monaco-editor/min/vs/editor/editor.main.css',
-          dest: 'monaco-editor/editor/editor.main.css'
-        },
-        {
           src: '../node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf',
-          dest: 'monaco-editor/base/browser/ui/codicons/codicon/codicon.ttf'
+          dest: 'assets/monaco-editor/codicon.ttf',
         },
       ],
     },
@@ -114,12 +110,8 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
       copy: [
         {
-          src: '../node_modules/monaco-editor/min/vs/editor/editor.main.css',
-          dest: 'monaco-editor/editor/editor.main.css'
-        },
-        {
           src: '../node_modules/monaco-editor/min/vs/base/browser/ui/codicons/codicon/codicon.ttf',
-          dest: 'monaco-editor/base/browser/ui/codicons/codicon/codicon.ttf'
+          dest: 'build/assets/monaco-editor/codicon.ttf',
         },
       ],
     }


### PR DESCRIPTION
1. In a previous attempt, we were distributing the monaco CSS file as an asset but in DNN context we had no great way to know in which path those files would actually live as we are producing components and not a website. So I reverted to using an scss import as that part was working right, it's only the font that was not working

2. In order to fix the font I discovered that chrome has a bug with fonts defined inside shadow-root and the workaround is to use scripts to import the font on the document head. I learned that one can use `import.meta.url` in the context of es-modules to get the URL to the module and not the page or otherwise.

3. For assets paths, since we have no clue where the path would be for a consumer, I learned that one can use `import.meta.url` inside an es-module to get the actual path where the module loaded from. We can now use this to reference the assets path correctly no matter where they get distributed by consumers.

4. I also learned that since Stencil supports workers out of the box, it is better to use `getWorker` rather than `getWorkerUrl` for performance and maybe we also avoid some path issues this way as Stencil will know what to bundle how.

5. I changed some monaco default options that I did not know existed. The most notable one being `ariaContainerElement`, unless this is set, the default is to inject the aria-text directly at the document end. I am now setting it to a local hidden div for screen-readers only and it no longer shows under the editor.