### PR TITLE
Fixed class name for `dnn-monaco-editor`

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -79,7 +79,7 @@
               "type": {
                 "text": "\"primary\" | \"secondary\" | \"tertiary\""
               },
-              "description": "Optional button style,\ncan be either primary, secondary or tertiary and defaults to primary if not specified",
+              "description": "Optional button style,\r\ncan be either primary, secondary or tertiary and defaults to primary if not specified",
               "default": "'primary'",
               "required": false
             }
@@ -353,7 +353,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https).",
+              "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https).",
               "default": "false",
               "required": false
             },
@@ -362,7 +362,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8",
+              "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8",
               "default": "0.8",
               "required": false
             }
@@ -374,7 +374,7 @@
               "type": {
                 "text": "string[]"
               },
-              "description": "A list of allowed file extensions.\nIf not specified, any file is allowed.\nEx: [\"jpg\", \"jped\", \"gif\", \"png\"]",
+              "description": "A list of allowed file extensions.\r\nIf not specified, any file is allowed.\r\nEx: [\"jpg\", \"jped\", \"gif\", \"png\"]",
               "required": false
             },
             {
@@ -384,7 +384,7 @@
                 "text": "{ dragAndDropFile: string; capture: string; or: string; takePicture: string; uploadFile: string; }"
               },
               "description": "Localization strings",
-              "default": "{\n    dragAndDropFile: \"Drag and drop a file\",\n    capture: \"Capture\",\n    or: \"or\",\n    takePicture: \"Take a picture\",\n    uploadFile: \"Upload a file\",\n  }",
+              "default": "{\r\n    dragAndDropFile: \"Drag and drop a file\",\r\n    capture: \"Capture\",\r\n    or: \"or\",\r\n    takePicture: \"Take a picture\",\r\n    uploadFile: \"Upload a file\",\r\n  }",
               "required": false
             }
           ],
@@ -424,7 +424,7 @@
           "kind": "class",
           "name": "dnn-image-cropper.tsx",
           "tagName": "dnn-image-cropper",
-          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image.",
+          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image.",
           "attributes": [
             {
               "name": "height",
@@ -470,8 +470,8 @@
               "type": {
                 "text": "{ capture: string; dragAndDropFile: string; or: string; takePicture: string; uploadFile: string; imageTooSmall: string; modalCloseText: string; }"
               },
-              "description": "Can be used to customize controls text.\nSome values support tokens, see default values for examples.",
-              "default": "{\n    capture: \"Capture\",\n    dragAndDropFile: \"Drag and drop an image\",\n    or: \"or\",\n    takePicture: \"Take a picture\",\n    uploadFile: \"Upload an image\",\n    imageTooSmall: \"The image you are attempting to upload does not meet the minimum size requirement of {width} pixels by {height} pixels. Please upload a larger image.\",\n    modalCloseText: \"Close\",\n  }",
+              "description": "Can be used to customize controls text.\r\nSome values support tokens, see default values for examples.",
+              "default": "{\r\n    capture: \"Capture\",\r\n    dragAndDropFile: \"Drag and drop an image\",\r\n    or: \"or\",\r\n    takePicture: \"Take a picture\",\r\n    uploadFile: \"Upload an image\",\r\n    imageTooSmall: \"The image you are attempting to upload does not meet the minimum size requirement of {width} pixels by {height} pixels. Please upload a larger image.\",\r\n    modalCloseText: \"Close\",\r\n  }",
               "required": false
             }
           ],
@@ -514,7 +514,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided.",
+              "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided.",
               "default": "\"Close modal\"",
               "required": false
             },
@@ -523,7 +523,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content.",
+              "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content.",
               "default": "true",
               "required": false
             },
@@ -677,7 +677,7 @@
                 "text": "ILocalization"
               },
               "description": "Optionally allows localizing the component strings.",
-              "default": "{\n    Add: \"Add\",\n    AllRoles: \"All Roles\",\n    FilterByGroup: \"Filter By Group\",\n    GlobalRoles: \"Global Roles\",\n    Role: \"Role\",\n    RolePermissions: \"Role Permissions\",\n    SelectRole: \"Select Role\",\n    User: \"User\",\n    UserPermissions: \"User Permissions\",\n  }",
+              "default": "{\r\n    Add: \"Add\",\r\n    AllRoles: \"All Roles\",\r\n    FilterByGroup: \"Filter By Group\",\r\n    GlobalRoles: \"Global Roles\",\r\n    Role: \"Role\",\r\n    RolePermissions: \"Role Permissions\",\r\n    SelectRole: \"Select Role\",\r\n    User: \"User\",\r\n    UserPermissions: \"User Permissions\",\r\n  }",
               "required": false
             },
             {
@@ -766,7 +766,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires up each time the search query changes.\nThe data passed is the new query."
+              "description": "Fires up each time the search query changes.\r\nThe data passed is the new query."
             }
           ],
           "slots": [],
@@ -1060,7 +1060,7 @@
           "kind": "class",
           "name": "dnn-vertical-splitview.tsx",
           "tagName": "dnn-vertical-splitview",
-          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
+          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
           "attributes": [
             {
               "name": "split-width-percentage",

--- a/licenses.json
+++ b/licenses.json
@@ -1,5 +1,5 @@
 {
-    "@babel/core@7.19.6": {
+    "@babel/core@7.17.8": {
         "licenses": "MIT",
         "repository": "https://github.com/babel/babel",
         "publisher": "The Babel Team",
@@ -82,7 +82,7 @@
         "path": "node_modules\\@storybook\\web-components",
         "licenseFile": "node_modules\\@storybook\\web-components\\LICENSE"
     },
-    "@types/jest@27.0.3": {
+    "@types/jest@27.4.1": {
         "licenses": "MIT",
         "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped",
         "path": "node_modules\\@types\\jest",
@@ -106,7 +106,7 @@
         "path": "node_modules\\@typescript-eslint\\parser",
         "licenseFile": "node_modules\\@typescript-eslint\\parser\\LICENSE"
     },
-    "babel-loader@8.2.5": {
+    "babel-loader@8.2.3": {
         "licenses": "MIT",
         "repository": "https://github.com/babel/babel-loader",
         "publisher": "Luis Couto",
@@ -114,9 +114,9 @@
         "path": "node_modules\\babel-loader",
         "licenseFile": "node_modules\\babel-loader\\LICENSE"
     },
-    "eslint-plugin-react@7.31.10": {
+    "eslint-plugin-react@7.29.4": {
         "licenses": "MIT",
-        "repository": "https://github.com/jsx-eslint/eslint-plugin-react",
+        "repository": "https://github.com/yannickcr/eslint-plugin-react",
         "publisher": "Yannick Croissant",
         "email": "yannick.croissant+npm@gmail.com",
         "path": "node_modules\\eslint-plugin-react",
@@ -151,7 +151,7 @@
         "path": "node_modules\\jest-cli",
         "licenseFile": "node_modules\\jest-cli\\LICENSE"
     },
-    "jest@27.0.3": {
+    "jest@27.5.1": {
         "licenses": "MIT",
         "repository": "https://github.com/facebook/jest",
         "path": "node_modules\\jest",
@@ -172,7 +172,7 @@
         "path": "node_modules\\lit-html",
         "licenseFile": "node_modules\\lit-html\\LICENSE"
     },
-    "monaco-editor@0.34.1": {
+    "monaco-editor@0.33.0": {
         "licenses": "MIT",
         "repository": "https://github.com/microsoft/monaco-editor",
         "publisher": "Microsoft Corporation",
@@ -186,7 +186,7 @@
         "path": "node_modules\\npm-run-all",
         "licenseFile": "node_modules\\npm-run-all\\LICENSE"
     },
-    "puppeteer@19.1.0": {
+    "puppeteer@19.3.0": {
         "licenses": "Apache-2.0",
         "repository": "https://github.com/puppeteer/puppeteer.git#main",
         "publisher": "The Chromium Authors",
@@ -200,7 +200,7 @@
         "path": "node_modules\\typescript-debounce-decorator",
         "licenseFile": "node_modules\\typescript-debounce-decorator\\LICENSE"
     },
-    "typescript@4.8.4": {
+    "typescript@4.6.2": {
         "licenses": "Apache-2.0",
         "repository": "https://github.com/Microsoft/TypeScript",
         "publisher": "Microsoft Corp.",

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -13,7 +13,7 @@ import { worker as editorWorker } from 'monaco-editor/esm/vs/editor/editor.worke
   styleUrl: 'dnn-monaco-editor.scss',
   shadow: true
 })
-export class MonacoEditor implements ComponentInterface {
+export class DnnMonacoEditor implements ComponentInterface {
   @Element() private el: HTMLDnnMonacoEditorElement;
 
   /** Sets the monaco editor options, see monaco options. */


### PR DESCRIPTION
Changed class name for the `dnn-monaco-editor` component from `MonacoEditor` to `DnnMonacoEditor`.  This naming convention is consistent with all the other `dnn-elements` components.