### PR TITLE
Updates GitVersion

### DIFF
--- a/_build/_build.csproj
+++ b/_build/_build.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[5.7.0]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.11.1]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The version of GitVersion that was used targetted .Net 5 and Github recently removed that version from runners. This attempts to upgrade GitVersion to see if it now targets .Net 6