### PR TITLE
Implemented loading `codicon.ttf` from CDN and local

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -580,7 +580,17 @@
           "name": "dnn-monaco-editor.tsx",
           "tagName": "dnn-monaco-editor",
           "description": "",
-          "attributes": [],
+          "attributes": [
+            {
+              "name": "load-font-from-local",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "If set to true, then it is the responsibility of the consumer to have codicon.ttf in their distribution (e.g., ./assets/monaco-editor/codicon.ttf).",
+              "default": "false",
+              "required": false
+            }
+          ],
           "members": [
             {
               "kind": "field",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -187,6 +187,10 @@ export namespace Components {
          */
         "getValue": () => Promise<string>;
         /**
+          * If set to true, then it is the responsibility of the consumer to have codicon.ttf in their distribution (e.g., ./assets/monaco-editor/codicon.ttf).
+         */
+        "loadFontFromLocal": boolean;
+        /**
           * Sets the monaco editor options, see monaco options.
          */
         "options": editor.IStandaloneEditorConstructionOptions;
@@ -683,6 +687,10 @@ declare namespace LocalJSX {
         "visible"?: boolean;
     }
     interface DnnMonacoEditor {
+        /**
+          * If set to true, then it is the responsibility of the consumer to have codicon.ttf in their distribution (e.g., ./assets/monaco-editor/codicon.ttf).
+         */
+        "loadFontFromLocal"?: boolean;
         /**
           * Event to indicate editor has loaded
          */

--- a/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
+++ b/src/components/dnn-monaco-editor/dnn-monaco-editor.tsx
@@ -19,6 +19,11 @@ export class DnnMonacoEditor implements ComponentInterface {
   /** Sets the monaco editor options, see monaco options. */
   @Prop() options: editor.IStandaloneEditorConstructionOptions;
 
+  /** Sets whether or not the codicon font is loaded from local. */
+  /** Default is false and the font will be loaded from https://unpkg.com/browse/@dnncommunity/dnn-elements@0.16.0-beta.4/dist/dnn/assets/monaco-editor/codicon.ttf */
+  /** If set to true, then it is the responsibility of the consumer to have codicon.ttf in their distribution (e.g., ./assets/monaco-editor/codicon.ttf). */
+  @Prop() loadFontFromLocal: boolean = false;
+
   /** Event to indicate editor has loaded */
   @Event() editorDidLoad: EventEmitter<void>;
 
@@ -63,8 +68,11 @@ export class DnnMonacoEditor implements ComponentInterface {
       }
     };
 
-    let path = import.meta.url.substring(0, import.meta.url.lastIndexOf('/'));
-    path = `${path}/assets/monaco-editor/codicon.ttf`;
+    let path = 'https://unpkg.com/monaco-editor@0.34.1/min/vs/base/browser/ui/codicons/codicon/codicon.ttf';
+    if (this.loadFontFromLocal) {
+      path = import.meta.url.substring(0, import.meta.url.lastIndexOf('/'));
+      path = `${path}/assets/monaco-editor/codicon.ttf`;
+    }
 
     const style = document.createElement('style');
     style.innerText = `@font-face { font-family: 'codicon'; src: url('${path}') format('truetype');}`;

--- a/src/components/dnn-monaco-editor/readme.md
+++ b/src/components/dnn-monaco-editor/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property  | Attribute | Description                                         | Type                                   | Default     |
-| --------- | --------- | --------------------------------------------------- | -------------------------------------- | ----------- |
-| `options` | --        | Sets the monaco editor options, see monaco options. | `IStandaloneEditorConstructionOptions` | `undefined` |
+| Property            | Attribute              | Description                                                                                                                                         | Type                                   | Default     |
+| ------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | ----------- |
+| `loadFontFromLocal` | `load-font-from-local` | If set to true, then it is the responsibility of the consumer to have codicon.ttf in their distribution (e.g., ./assets/monaco-editor/codicon.ttf). | `boolean`                              | `false`     |
+| `options`           | --                     | Sets the monaco editor options, see monaco options.                                                                                                 | `IStandaloneEditorConstructionOptions` | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
The `codicon.ttf` file was not, by default, accessible for consumers.  Therefore, we needed to default loading the font from CDN.  We opted for using the font from the `monaco-editor` repo.  We will need to keep the version in the `unpkg` URL in sync with the version of `monaco-editor` being used in `dnn-elements`.