### PR TITLE
Resolve issue with logo by using local assets in storybook

### DIFF
--- a/.storybook/assets/DNNLogo.svg
+++ b/.storybook/assets/DNNLogo.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="499.9px" height="197.2px" viewBox="-6.1 -1 499.9 197.2" enable-background="new -6.1 -1 499.9 197.2"
+	 xml:space="preserve">
+<g>
+	<g>
+		<path fill="#FFFFFF" d="M271.6,119.3h-14.8V90h14.8c8.2,0,14.8,6.6,14.8,14.8C286.4,113,279.5,119.3,271.6,119.3 M271.6,64.7h-40.8v79.9h40.8c22,0,39.8-17.7,39.8-40.1C311.4,82.4,293.6,64.7,271.6,64.7"/>
+		<path fill="#FFFFFF" d="M401.4,104.1c-0.3-22-18.1-39.4-39.8-39.4h-39.8v79.9h26V90.7h13.8c7.9,0,14.1,6.2,14.1,14.1v40.1h26L401.4,104.1L401.4,104.1z"/>
+		<path fill="#FFFFFF" d="M493.5,104.1c-0.3-22-18.1-39.4-39.8-39.4h-40.1v79.9h26V90.7h14.1c7.6,0,14.1,6.2,14.1,14.1v40.1h26L493.5,104.1L493.5,104.1z"/>
+	</g>
+	<g>
+		<path fill="#EF3E42" d="M125.4,64.7V4.6C115.2,0.9,104-1,92.5-1H-6.1v131.5h65.7V64.7H125.4z"/>
+		 <path fill="#472A2B" d="M125.4,64.7H59.6v65.7h32.9c18.1,0,32.9-14.8,32.9-32.9l0,0V64.7L125.4,64.7z"/>
+		<path fill="#FFFFFF" d="M125.4,4.6v60.1h60.1C175.3,36.8,153.3,14.4,125.4,4.6z M-6.1,196.2h65.7v-65.7H-6.1V196.2z"/>
+		<path fill="#00A4E4" d="M185.5,64.7h-60.1v32.9l0,0c0,18.1-14.8,32.9-32.9,32.9H59.6v65.7h32.9c54.6,0,98.6-44,98.6-98.6C191.1,86.1,189.1,74.9,185.5,64.7z"/>
+	</g>
+</g>
+</svg>

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,5 +7,6 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials"
   ],
-  "framework": "@storybook/web-components"
+  "framework": "@storybook/web-components",
+  "staticDirs": [{ from: './assets', to: '/assets'}]
 }

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -25,7 +25,7 @@ const theme = create({
 
   // BRAND
   brandTitle: 'DNN Elements',
-  brandImage: 'https://dnncommunity.org/Portals/0/DNN_White_Logo_lg.png'
+  brandImage: '/assets/DNNLogo.svg'
 });
 
 addons.setConfig({

--- a/licenses.json
+++ b/licenses.json
@@ -7,7 +7,7 @@
         "path": "node_modules\\@babel\\core",
         "licenseFile": "node_modules\\@babel\\core\\LICENSE"
     },
-    "@dnncommunity/dnn-elements@0.16.0-storybook.1": {
+    "@dnncommunity/dnn-elements@0.16.1-beta.1": {
         "licenses": "MIT",
         "repository": "https://github.com/dnncommunity/dnn-elements",
         "path": "",


### PR DESCRIPTION
This PR implements the use of `staticDirs` for utilizing local assets and deploying them to the storybook site.