### PR TITLE
Resolve GitHub Pages path to assets and copy Stencil components the same way

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,5 +8,5 @@ module.exports = {
     "@storybook/addon-essentials"
   ],
   "framework": "@storybook/web-components",
-  "staticDirs": [{ from: './assets', to: '/assets'}]
+  "staticDirs": [{ from: './assets', to: '/assets'}, { from: '../dist/dnn', to: '/dnn'}]
 }

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -25,7 +25,7 @@ const theme = create({
 
   // BRAND
   brandTitle: 'DNN Elements',
-  brandImage: '/assets/DNNLogo.svg'
+  brandImage: 'assets/DNNLogo.svg'
 });
 
 addons.setConfig({


### PR DESCRIPTION
This PR attempts to resolve the path issues to the logo asset on GitHub Pages.  It also attempts to ensure the web components dist is copied over to the site branch in the same way assets are now handled.