### PR TITLE
Removed typescript from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lit-html": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "puppeteer": "^19.1.0",
-    "typescript": "^4.5.5",
     "typescript-debounce-decorator": "^0.0.18"
   },
   "dependencies": {


### PR DESCRIPTION
We do not need to specify the typescript dependency since @stencil/eslint-plugin v0.4+ which declares it itself (and @stencil/core too). This way we use the version range defined there instead of our own which makes dependency management possibly easier