### PR TITLE
Fixed a console error when not using drag on dnn-modal

### DIFF
--- a/packages/stencil-library/src/components/dnn-modal/dnn-modal.tsx
+++ b/packages/stencil-library/src/components/dnn-modal/dnn-modal.tsx
@@ -65,7 +65,7 @@ export class DnnModal {
 
   
   disconnectedCallback() {
-    this.seDrag.removeEventListener("mousedown", this.handleResizeMouseDown);
+    this.seDrag?.removeEventListener("mousedown", this.handleResizeMouseDown);
     removeEventListener("mouseup", this.handleResizeMouseUp);
   }
   


### PR DESCRIPTION
An event listener was being removed on a element that could possibly not exists.

Closes Drag event needs to be removed only if attached #758