### PR TITLE
Fixed an issue with label alignment of inputs

### DIFF
--- a/packages/stencil-library/src/components/dnn-input/dnn-input.scss
+++ b/packages/stencil-library/src/components/dnn-input/dnn-input.scss
@@ -48,6 +48,7 @@
     white-space: nowrap;
     max-width: 100%;
     border-radius: var(--control-radius);
+    font-size: 1rem;
   }
   input{
     border: none;
@@ -119,7 +120,7 @@ button.show-password{
   margin: 0;
   padding: 0;
   svg{
-    height: 1em;
+    height: 1rem;
     width: auto;
     fill: var(--foreground);
     transform: scale(1.5);

--- a/packages/stencil-library/src/components/dnn-select/dnn-select.scss
+++ b/packages/stencil-library/src/components/dnn-select/dnn-select.scss
@@ -48,6 +48,7 @@
     white-space: nowrap;
     max-width: 100%;
     border-radius: var(--control-radius);
+    font-size: 1rem;
   }
   select{
     border: none;


### PR DESCRIPTION
dnn-input and dnn-select were having alignment issues when used in situations where the label would not have the same font-size as the body.

This makes the label be 1rem so that we can align it with an expected size.