### PR TITLE
Configured Jest to use `new` headless mode

### DIFF
--- a/packages/stencil-library/stencil.config.ts
+++ b/packages/stencil-library/stencil.config.ts
@@ -123,4 +123,7 @@ export const config: Config = {
     ]
   },
   sourceMap: true,
+  testing: {
+    browserHeadless: "new",
+  }
 };


### PR DESCRIPTION
This should allow us to then upgrade jest to the latest version