### PR TITLE
Improved validation display of dnn-dropzone

### DIFF
--- a/packages/stencil-library/licenses.json
+++ b/packages/stencil-library/licenses.json
@@ -1,20 +1,80 @@
 {
+    "@babel/code-frame@7.12.11": {
+        "licenses": "MIT",
+        "repository": "https://github.com/babel/babel",
+        "publisher": "Sebastian McKenzie",
+        "email": "sebmck@gmail.com",
+        "path": "node_modules\\@babel\\code-frame",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@babel\\code-frame\\LICENSE"
+    },
     "@dnncommunity/dnn-elements@0.18.0-alpha.61": {
         "licenses": "MIT",
         "repository": "https://github.com/dnncommunity/dnn-elements",
         "path": ""
     },
+    "@eslint/eslintrc@0.4.3": {
+        "licenses": "MIT",
+        "repository": "https://github.com/eslint/eslintrc",
+        "publisher": "Nicholas C. Zakas",
+        "path": "node_modules\\@eslint\\eslintrc",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@eslint\\eslintrc\\LICENSE"
+    },
+    "@humanwhocodes/config-array@0.5.0": {
+        "licenses": "Apache-2.0",
+        "repository": "https://github.com/humanwhocodes/config-array",
+        "publisher": "Nicholas C. Zakas",
+        "path": "node_modules\\@humanwhocodes\\config-array",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@humanwhocodes\\config-array\\LICENSE"
+    },
     "@stencil/eslint-plugin@0.4.0": {
         "licenses": "MIT",
         "repository": "https://github.com/ionic-team/stencil-eslint",
         "path": "node_modules\\@stencil\\eslint-plugin",
-        "licenseFile": "node_modules\\@stencil\\eslint-plugin\\LICENSE.md"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@stencil\\eslint-plugin\\LICENSE.md"
     },
     "@typescript-eslint/parser@4.33.0": {
         "licenses": "BSD-2-Clause",
         "repository": "https://github.com/typescript-eslint/typescript-eslint",
         "path": "node_modules\\@typescript-eslint\\parser",
-        "licenseFile": "node_modules\\@typescript-eslint\\parser\\LICENSE"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\parser\\LICENSE"
+    },
+    "@typescript-eslint/scope-manager@4.33.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/typescript-eslint/typescript-eslint",
+        "path": "node_modules\\@typescript-eslint\\scope-manager",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\scope-manager\\LICENSE"
+    },
+    "@typescript-eslint/types@4.33.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/typescript-eslint/typescript-eslint",
+        "path": "node_modules\\@typescript-eslint\\types",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\types\\LICENSE"
+    },
+    "@typescript-eslint/typescript-estree@4.33.0": {
+        "licenses": "BSD-2-Clause",
+        "repository": "https://github.com/typescript-eslint/typescript-eslint",
+        "path": "node_modules\\@typescript-eslint\\typescript-estree",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\typescript-estree\\LICENSE"
+    },
+    "@typescript-eslint/visitor-keys@4.33.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/typescript-eslint/typescript-eslint",
+        "path": "node_modules\\@typescript-eslint\\visitor-keys",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\visitor-keys\\LICENSE"
+    },
+    "eslint-utils@2.1.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/mysticatea/eslint-utils",
+        "publisher": "Toru Nagashima",
+        "path": "node_modules\\eslint\\node_modules\\eslint-utils",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\eslint\\node_modules\\eslint-utils\\LICENSE"
+    },
+    "eslint-visitor-keys@1.3.0": {
+        "licenses": "Apache-2.0",
+        "repository": "https://github.com/eslint/eslint-visitor-keys",
+        "publisher": "Toru Nagashima",
+        "path": "node_modules\\espree\\node_modules\\eslint-visitor-keys",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\espree\\node_modules\\eslint-visitor-keys\\LICENSE"
     },
     "eslint@7.32.0": {
         "licenses": "MIT",
@@ -22,7 +82,22 @@
         "publisher": "Nicholas C. Zakas",
         "email": "nicholas+npm@nczconsulting.com",
         "path": "node_modules\\eslint",
-        "licenseFile": "node_modules\\eslint\\LICENSE"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\eslint\\LICENSE"
+    },
+    "espree@7.3.1": {
+        "licenses": "BSD-2-Clause",
+        "repository": "https://github.com/eslint/espree",
+        "publisher": "Nicholas C. Zakas",
+        "email": "nicholas+npm@nczconsulting.com",
+        "path": "node_modules\\espree",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\espree\\LICENSE"
+    },
+    "ignore@4.0.6": {
+        "licenses": "MIT",
+        "repository": "https://github.com/kaelzhang/node-ignore",
+        "publisher": "kael",
+        "path": "node_modules\\ignore",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\ignore\\LICENSE-MIT"
     },
     "jodit@3.24.9": {
         "licenses": "MIT",
@@ -30,13 +105,34 @@
         "publisher": "Chupurnov",
         "email": "chupurnov@gmail.com",
         "path": "node_modules\\jodit",
-        "licenseFile": "node_modules\\jodit\\LICENSE.txt"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\jodit\\LICENSE.txt"
+    },
+    "tslib@1.14.1": {
+        "licenses": "0BSD",
+        "repository": "https://github.com/Microsoft/tslib",
+        "publisher": "Microsoft Corp.",
+        "path": "node_modules\\tslib",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\tslib\\LICENSE.txt"
+    },
+    "tsutils@3.0.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/ajafff/tsutils",
+        "publisher": "Klaus Meinhardt",
+        "path": "node_modules\\tsutils",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\tsutils\\LICENSE"
+    },
+    "tsutils@3.21.0": {
+        "licenses": "MIT",
+        "repository": "https://github.com/ajafff/tsutils",
+        "publisher": "Klaus Meinhardt",
+        "path": "node_modules\\@typescript-eslint\\typescript-estree\\node_modules\\tsutils",
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\@typescript-eslint\\typescript-estree\\node_modules\\tsutils\\LICENSE"
     },
     "typescript@4.9.5": {
         "licenses": "Apache-2.0",
         "repository": "https://github.com/Microsoft/TypeScript",
         "publisher": "Microsoft Corp.",
         "path": "node_modules\\typescript",
-        "licenseFile": "node_modules\\typescript\\LICENSE.txt"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\node_modules\\typescript\\LICENSE.txt"
     }
 }

--- a/packages/stencil-library/src/components.d.ts
+++ b/packages/stencil-library/src/components.d.ts
@@ -592,87 +592,223 @@ export interface DnnVerticalSplitviewCustomEvent<T> extends CustomEvent<T> {
     target: HTMLDnnVerticalSplitviewElement;
 }
 declare global {
+    interface HTMLDnnButtonElementEventMap {
+        "confirmed": any;
+        "canceled": any;
+    }
     interface HTMLDnnButtonElement extends Components.DnnButton, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnButtonElementEventMap>(type: K, listener: (this: HTMLDnnButtonElement, ev: DnnButtonCustomEvent<HTMLDnnButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnButtonElementEventMap>(type: K, listener: (this: HTMLDnnButtonElement, ev: DnnButtonCustomEvent<HTMLDnnButtonElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnButtonElement: {
         prototype: HTMLDnnButtonElement;
         new (): HTMLDnnButtonElement;
     };
+    interface HTMLDnnCheckboxElementEventMap {
+        "checkedchange": "checked" | "unchecked" | "intermediate";
+    }
     interface HTMLDnnCheckboxElement extends Components.DnnCheckbox, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnCheckboxElementEventMap>(type: K, listener: (this: HTMLDnnCheckboxElement, ev: DnnCheckboxCustomEvent<HTMLDnnCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnCheckboxElementEventMap>(type: K, listener: (this: HTMLDnnCheckboxElement, ev: DnnCheckboxCustomEvent<HTMLDnnCheckboxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnCheckboxElement: {
         prototype: HTMLDnnCheckboxElement;
         new (): HTMLDnnCheckboxElement;
     };
+    interface HTMLDnnChevronElementEventMap {
+        "changed": any;
+    }
     interface HTMLDnnChevronElement extends Components.DnnChevron, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnChevronElementEventMap>(type: K, listener: (this: HTMLDnnChevronElement, ev: DnnChevronCustomEvent<HTMLDnnChevronElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnChevronElementEventMap>(type: K, listener: (this: HTMLDnnChevronElement, ev: DnnChevronCustomEvent<HTMLDnnChevronElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnChevronElement: {
         prototype: HTMLDnnChevronElement;
         new (): HTMLDnnChevronElement;
     };
+    interface HTMLDnnCollapsibleElementEventMap {
+        "dnnCollapsibleHeightChanged": void;
+    }
     interface HTMLDnnCollapsibleElement extends Components.DnnCollapsible, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnCollapsibleElementEventMap>(type: K, listener: (this: HTMLDnnCollapsibleElement, ev: DnnCollapsibleCustomEvent<HTMLDnnCollapsibleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnCollapsibleElementEventMap>(type: K, listener: (this: HTMLDnnCollapsibleElement, ev: DnnCollapsibleCustomEvent<HTMLDnnCollapsibleElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnCollapsibleElement: {
         prototype: HTMLDnnCollapsibleElement;
         new (): HTMLDnnCollapsibleElement;
     };
+    interface HTMLDnnColorInputElementEventMap {
+        "colorChange": DnnColorInfo;
+        "colorInput": DnnColorInfo;
+    }
     /**
      * A custom input component that allows previewing and changing a color value.
      */
     interface HTMLDnnColorInputElement extends Components.DnnColorInput, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnColorInputElementEventMap>(type: K, listener: (this: HTMLDnnColorInputElement, ev: DnnColorInputCustomEvent<HTMLDnnColorInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnColorInputElementEventMap>(type: K, listener: (this: HTMLDnnColorInputElement, ev: DnnColorInputCustomEvent<HTMLDnnColorInputElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnColorInputElement: {
         prototype: HTMLDnnColorInputElement;
         new (): HTMLDnnColorInputElement;
     };
+    interface HTMLDnnColorPickerElementEventMap {
+        "colorChanged": ColorInfo;
+    }
     /**
      * Color Picker for Dnn
      */
     interface HTMLDnnColorPickerElement extends Components.DnnColorPicker, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnColorPickerElementEventMap>(type: K, listener: (this: HTMLDnnColorPickerElement, ev: DnnColorPickerCustomEvent<HTMLDnnColorPickerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnColorPickerElementEventMap>(type: K, listener: (this: HTMLDnnColorPickerElement, ev: DnnColorPickerCustomEvent<HTMLDnnColorPickerElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnColorPickerElement: {
         prototype: HTMLDnnColorPickerElement;
         new (): HTMLDnnColorPickerElement;
     };
+    interface HTMLDnnDropzoneElementEventMap {
+        "filesSelected": File[];
+    }
     interface HTMLDnnDropzoneElement extends Components.DnnDropzone, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnDropzoneElementEventMap>(type: K, listener: (this: HTMLDnnDropzoneElement, ev: DnnDropzoneCustomEvent<HTMLDnnDropzoneElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnDropzoneElementEventMap>(type: K, listener: (this: HTMLDnnDropzoneElement, ev: DnnDropzoneCustomEvent<HTMLDnnDropzoneElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnDropzoneElement: {
         prototype: HTMLDnnDropzoneElement;
         new (): HTMLDnnDropzoneElement;
     };
+    interface HTMLDnnImageCropperElementEventMap {
+        "imageCropChanged": string;
+    }
     /**
      * Allows cropping an image in-browser with the option to enforce a specific final size.
      * All computation happens in the browser and the final image is emmited
      * in an event that has a data-url of the image.
      */
     interface HTMLDnnImageCropperElement extends Components.DnnImageCropper, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnImageCropperElementEventMap>(type: K, listener: (this: HTMLDnnImageCropperElement, ev: DnnImageCropperCustomEvent<HTMLDnnImageCropperElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnImageCropperElementEventMap>(type: K, listener: (this: HTMLDnnImageCropperElement, ev: DnnImageCropperCustomEvent<HTMLDnnImageCropperElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnImageCropperElement: {
         prototype: HTMLDnnImageCropperElement;
         new (): HTMLDnnImageCropperElement;
     };
+    interface HTMLDnnInputElementEventMap {
+        "valueChange": number | string | string[];
+        "valueInput": number | string | string[];
+    }
     /**
      * A custom input component that wraps the html input element is a mobile friendly component that supports a label, some help text and other features.
      */
     interface HTMLDnnInputElement extends Components.DnnInput, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnInputElementEventMap>(type: K, listener: (this: HTMLDnnInputElement, ev: DnnInputCustomEvent<HTMLDnnInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnInputElementEventMap>(type: K, listener: (this: HTMLDnnInputElement, ev: DnnInputCustomEvent<HTMLDnnInputElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnInputElement: {
         prototype: HTMLDnnInputElement;
         new (): HTMLDnnInputElement;
     };
+    interface HTMLDnnModalElementEventMap {
+        "dismissed": any;
+    }
     interface HTMLDnnModalElement extends Components.DnnModal, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnModalElementEventMap>(type: K, listener: (this: HTMLDnnModalElement, ev: DnnModalCustomEvent<HTMLDnnModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnModalElementEventMap>(type: K, listener: (this: HTMLDnnModalElement, ev: DnnModalCustomEvent<HTMLDnnModalElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnModalElement: {
         prototype: HTMLDnnModalElement;
         new (): HTMLDnnModalElement;
     };
+    interface HTMLDnnMonacoEditorElementEventMap {
+        "contentChanged": string;
+    }
     interface HTMLDnnMonacoEditorElement extends Components.DnnMonacoEditor, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnMonacoEditorElementEventMap>(type: K, listener: (this: HTMLDnnMonacoEditorElement, ev: DnnMonacoEditorCustomEvent<HTMLDnnMonacoEditorElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnMonacoEditorElementEventMap>(type: K, listener: (this: HTMLDnnMonacoEditorElement, ev: DnnMonacoEditorCustomEvent<HTMLDnnMonacoEditorElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnMonacoEditorElement: {
         prototype: HTMLDnnMonacoEditorElement;
         new (): HTMLDnnMonacoEditorElement;
     };
+    interface HTMLDnnPermissionsGridElementEventMap {
+        "userSearchQueryChanged": string;
+        "permissionsChanged": IPermissions;
+    }
     interface HTMLDnnPermissionsGridElement extends Components.DnnPermissionsGrid, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnPermissionsGridElementEventMap>(type: K, listener: (this: HTMLDnnPermissionsGridElement, ev: DnnPermissionsGridCustomEvent<HTMLDnnPermissionsGridElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnPermissionsGridElementEventMap>(type: K, listener: (this: HTMLDnnPermissionsGridElement, ev: DnnPermissionsGridCustomEvent<HTMLDnnPermissionsGridElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnPermissionsGridElement: {
         prototype: HTMLDnnPermissionsGridElement;
@@ -684,25 +820,70 @@ declare global {
         prototype: HTMLDnnProgressBarElement;
         new (): HTMLDnnProgressBarElement;
     };
+    interface HTMLDnnRichtextElementEventMap {
+        "valueChange": string;
+        "valueInput": string;
+    }
     interface HTMLDnnRichtextElement extends Components.DnnRichtext, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnRichtextElementEventMap>(type: K, listener: (this: HTMLDnnRichtextElement, ev: DnnRichtextCustomEvent<HTMLDnnRichtextElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnRichtextElementEventMap>(type: K, listener: (this: HTMLDnnRichtextElement, ev: DnnRichtextCustomEvent<HTMLDnnRichtextElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnRichtextElement: {
         prototype: HTMLDnnRichtextElement;
         new (): HTMLDnnRichtextElement;
     };
+    interface HTMLDnnSearchboxElementEventMap {
+        "queryChanged": string;
+    }
     interface HTMLDnnSearchboxElement extends Components.DnnSearchbox, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnSearchboxElementEventMap>(type: K, listener: (this: HTMLDnnSearchboxElement, ev: DnnSearchboxCustomEvent<HTMLDnnSearchboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnSearchboxElementEventMap>(type: K, listener: (this: HTMLDnnSearchboxElement, ev: DnnSearchboxCustomEvent<HTMLDnnSearchboxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnSearchboxElement: {
         prototype: HTMLDnnSearchboxElement;
         new (): HTMLDnnSearchboxElement;
     };
+    interface HTMLDnnSelectElementEventMap {
+        "valueChange": string;
+    }
     interface HTMLDnnSelectElement extends Components.DnnSelect, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnSelectElementEventMap>(type: K, listener: (this: HTMLDnnSelectElement, ev: DnnSelectCustomEvent<HTMLDnnSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnSelectElementEventMap>(type: K, listener: (this: HTMLDnnSelectElement, ev: DnnSelectCustomEvent<HTMLDnnSelectElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnSelectElement: {
         prototype: HTMLDnnSelectElement;
         new (): HTMLDnnSelectElement;
     };
+    interface HTMLDnnSortIconElementEventMap {
+        "sortChanged": "asc"|"desc"|"none";
+    }
     interface HTMLDnnSortIconElement extends Components.DnnSortIcon, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnSortIconElementEventMap>(type: K, listener: (this: HTMLDnnSortIconElement, ev: DnnSortIconCustomEvent<HTMLDnnSortIconElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnSortIconElementEventMap>(type: K, listener: (this: HTMLDnnSortIconElement, ev: DnnSortIconCustomEvent<HTMLDnnSortIconElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnSortIconElement: {
         prototype: HTMLDnnSortIconElement;
@@ -723,13 +904,36 @@ declare global {
         prototype: HTMLDnnTabsElement;
         new (): HTMLDnnTabsElement;
     };
+    interface HTMLDnnToggleElementEventMap {
+        "checkChanged": DnnToggleChangeEventDetail;
+    }
     interface HTMLDnnToggleElement extends Components.DnnToggle, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnToggleElementEventMap>(type: K, listener: (this: HTMLDnnToggleElement, ev: DnnToggleCustomEvent<HTMLDnnToggleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnToggleElementEventMap>(type: K, listener: (this: HTMLDnnToggleElement, ev: DnnToggleCustomEvent<HTMLDnnToggleElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnToggleElement: {
         prototype: HTMLDnnToggleElement;
         new (): HTMLDnnToggleElement;
     };
+    interface HTMLDnnTreeviewItemElementEventMap {
+        "userExpanded": void;
+        "userCollapsed": void;
+    }
     interface HTMLDnnTreeviewItemElement extends Components.DnnTreeviewItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnTreeviewItemElementEventMap>(type: K, listener: (this: HTMLDnnTreeviewItemElement, ev: DnnTreeviewItemCustomEvent<HTMLDnnTreeviewItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnTreeviewItemElementEventMap>(type: K, listener: (this: HTMLDnnTreeviewItemElement, ev: DnnTreeviewItemCustomEvent<HTMLDnnTreeviewItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnTreeviewItemElement: {
         prototype: HTMLDnnTreeviewItemElement;
@@ -744,7 +948,18 @@ declare global {
         prototype: HTMLDnnVerticalOverflowMenuElement;
         new (): HTMLDnnVerticalOverflowMenuElement;
     };
+    interface HTMLDnnVerticalSplitviewElementEventMap {
+        "widthChanged": number;
+    }
     interface HTMLDnnVerticalSplitviewElement extends Components.DnnVerticalSplitview, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLDnnVerticalSplitviewElementEventMap>(type: K, listener: (this: HTMLDnnVerticalSplitviewElement, ev: DnnVerticalSplitviewCustomEvent<HTMLDnnVerticalSplitviewElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLDnnVerticalSplitviewElementEventMap>(type: K, listener: (this: HTMLDnnVerticalSplitviewElement, ev: DnnVerticalSplitviewCustomEvent<HTMLDnnVerticalSplitviewElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLDnnVerticalSplitviewElement: {
         prototype: HTMLDnnVerticalSplitviewElement;

--- a/packages/stencil-library/src/components/dnn-dropzone/types.ts
+++ b/packages/stencil-library/src/components/dnn-dropzone/types.ts
@@ -1,9 +1,30 @@
 export interface DropzoneResx {
+    /** The title of the control text. */
     dragAndDropFile?: string;
+
+    /** The word used for the picture mode capture button. */
     capture?: string;
+
+    //** The word "or" shown between different control options. */
     or?: string;
+
+    /** The text of the button to take a picture.*/
     takePicture?: string;
+
+    /** The text of the control to pick a file. */
     uploadFile?: string;
+
+    /** The text displayed when attempting to upload a file that is too large. */
     uploadSizeTooLarge?: string;
+
+    /** The information displayed about the filesize limit.
+     * {0} will be replaced by a human friendly size. (in MB, KB, GB, etc.) */
     fileSizeLimit?: string;
+
+    /** The text displayed when attempting to upload a file type that is not allowed. */
+    invalidExtension?: string;
+
+    /** The information displayed about the allowed file extensions.
+     * {0} will be replaced by a comma separated list of allowed extensions. */
+    allowedFileExtensions?: string;
 }

--- a/packages/stencil-library/src/index.html
+++ b/packages/stencil-library/src/index.html
@@ -776,9 +776,10 @@
   <section>
     <h2>dnn-dropzone</h2>
     <p>Allows dropping a file, selecting a file or taking a picture with the device camera.</p>
-    <dnn-dropzone max-file-size='100000' allow-camera-mode id="dnnDropZone" />
+    <dnn-dropzone max-file-size='10000' allow-camera-mode id="dnnDropZone" />
     <script type="text/javascript">
       const dnnDropZone = document.querySelector("#dnnDropZone");
+      dnnDropZone.allowedExtensions = ["jpg", "png", "gif", "pdf"];
       dnnDropZone.addEventListener("filesSelected", e => console.log(e.detail));
     </script>
   </section>


### PR DESCRIPTION
Previously when dropping files (not picking), the component would not provide any feedback, it would simply not fire the dropped event.

With this change, it will display a localizable error message if the file is too large or of an unsupported extension.