### PR TITLE
Fixed a casing issue on validation of allowed extensions

### DIFF
--- a/packages/stencil-library/src/components/dnn-dropzone/dnn-dropzone.tsx
+++ b/packages/stencil-library/src/components/dnn-dropzone/dnn-dropzone.tsx
@@ -157,12 +157,13 @@ export class DnnDropzone {
     for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
       const file = files[fileIndex];
       var regex = /(?:\.([^.]+))?$/;
-      const fileExtension = regex.exec(file.name)[1];
+      const fileExtension = regex.exec(file.name)[1]?.toLowerCase();
       if (fileExtension == undefined){
         hasInvalid = true;
       }
 
-      if (this.allowedExtensions != undefined && !this.allowedExtensions.includes(fileExtension)){
+      var loweredAllowedExtensions = this.allowedExtensions.map(e => e.toLowerCase());
+      if (this.allowedExtensions != undefined && !loweredAllowedExtensions.includes(fileExtension)){
         hasInvalid = true;
       }
 


### PR DESCRIPTION
In the browser, both lowercased "jpg" or uppercased "JPG" are allowed for an image file. The check for allowed extensions in the dropzone control was case sensitive block upload of valid image files in dnn-image-cropper and potentially other usages.