### PR TITLE
Resolved issue with `--color-text` not applying to inactive tab text color

### DIFF
--- a/packages/stencil-library/src/components/dnn-tabs/dnn-tabs.scss
+++ b/packages/stencil-library/src/components/dnn-tabs/dnn-tabs.scss
@@ -17,17 +17,17 @@
 .tabTitles{
     display: flex;
     background-color: var(--color-background);
-    color: var(--color-text);
     button {
         cursor: pointer; 
         padding: 0.5rem 1rem;
         border: 0;
         margin: 0;
         background-color: transparent;
+        color: var(--color-text);
         
         &.visible {
             background-color: var(--color-visible);
-            color: var(--color-bisible-text);
+            color: var(--color-visible-text);
         }
             
         &:focus, &:hover {


### PR DESCRIPTION
This PR resolves an issue with `--color-text` not applying to the inactive tab text color.  

It also resolves a typo in a CSS var name that would prevent the style from applying to the visible (currently active) tab text color.

Resolves #997 