### PR TITLE
Fixed an issue that caused too few large bundles

### DIFF
--- a/packages/stencil-library/custom-elements.json
+++ b/packages/stencil-library/custom-elements.json
@@ -48,7 +48,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "How many suggestions to preload in pixels of their height.\r\nThis is used to calculate the virtual scroll height and request\r\nmore items before they get into view.",
+              "description": "How many suggestions to preload in pixels of their height.\nThis is used to calculate the virtual scroll height and request\nmore items before they get into view.",
               "default": "1000",
               "required": false
             },
@@ -65,7 +65,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "The total amount of suggestions for the given search query.\r\nThis can be used to show virtual scroll and pagination progressive feeding.\r\nThe needMoreItems event should be used to request more items.",
+              "description": "The total amount of suggestions for the given search query.\nThis can be used to show virtual scroll and pagination progressive feeding.\nThe needMoreItems event should be used to request more items.",
               "required": false
             },
             {
@@ -130,7 +130,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires when the search query has changed.\r\nThis is almost like valueInput, but it is debounced\r\nand can be used to trigger a search query without overloading\r\nAPI endpoints while typing."
+              "description": "Fires when the search query has changed.\nThis is almost like valueInput, but it is debounced\nand can be used to trigger a search query without overloading\nAPI endpoints while typing."
             },
             {
               "name": "valueChange",
@@ -234,7 +234,7 @@
               "type": {
                 "text": "\"button\" | \"reset\" | \"submit\""
               },
-              "description": "Optional button type,\r\ncan be either submit, reset or button and defaults to button if not specified.\r\nWarning: DNN wraps the whole page in a form, only use this if you are handling\r\nform submission manually.",
+              "description": "Optional button type,\ncan be either submit, reset or button and defaults to button if not specified.\nWarning: DNN wraps the whole page in a form, only use this if you are handling\nform submission manually.",
               "default": "'button'",
               "required": false
             },
@@ -261,7 +261,7 @@
               "type": {
                 "text": "\"danger\" | \"primary\" | \"secondary\" | \"tertiary\""
               },
-              "description": "Optional button style,\r\ncan be either primary, secondary or tertiary or danger and defaults to primary if not specified",
+              "description": "Optional button style,\ncan be either primary, secondary or tertiary or danger and defaults to primary if not specified",
               "default": "'primary'",
               "required": false
             }
@@ -620,7 +620,7 @@
                 "text": "{ contrast: string; preview: string; cancel: string; confirm: string; normal: string; light: string; dark: string; }"
               },
               "description": "Can be used to customize the text language.",
-              "default": "{\r\n    contrast: \"Contrast\",\r\n    preview: \"Preview\",\r\n    cancel: \"Cancel\",\r\n    confirm: \"Confirm\",\r\n    normal: \"Normal\",\r\n    light: \"Light\",\r\n    dark: \"Dark\",\r\n  }",
+              "default": "{\n    contrast: \"Contrast\",\n    preview: \"Preview\",\n    cancel: \"Cancel\",\n    confirm: \"Confirm\",\n    normal: \"Normal\",\n    light: \"Light\",\n    dark: \"Dark\",\n  }",
               "required": false
             }
           ],
@@ -736,7 +736,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https).",
+              "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https).",
               "default": "false",
               "required": false
             },
@@ -745,7 +745,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8",
+              "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8",
               "default": "0.8",
               "required": false
             },
@@ -773,7 +773,7 @@
               "type": {
                 "text": "string[]"
               },
-              "description": "A list of allowed file extensions.\r\nIf not specified, any file is allowed.\r\nEx: [\"jpg\", \"jpeg\", \"gif\", \"png\"]",
+              "description": "A list of allowed file extensions.\nIf not specified, any file is allowed.\nEx: [\"jpg\", \"jpeg\", \"gif\", \"png\"]",
               "required": false
             },
             {
@@ -989,7 +989,7 @@
           "kind": "class",
           "name": "dnn-image-cropper.tsx",
           "tagName": "dnn-image-cropper",
-          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image.",
+          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image.",
           "attributes": [
             {
               "name": "height",
@@ -1041,7 +1041,7 @@
               "type": {
                 "text": "ImageCropperResx"
               },
-              "description": "Can be used to customize controls text.\r\nSome values support tokens, see default values for examples.",
+              "description": "Can be used to customize controls text.\nSome values support tokens, see default values for examples.",
               "required": false
             },
             {
@@ -1064,7 +1064,7 @@
               "type": {
                 "text": "File"
               },
-              "description": "Emits both when a file is initially select and when the crop has changed.\r\nCompared to imageCropChanged, this event emits the file itself, which can be useful for uploading the file to a server including its name."
+              "description": "Emits both when a file is initially select and when the crop has changed.\nCompared to imageCropChanged, this event emits the file itself, which can be useful for uploading the file to a server including its name."
             }
           ],
           "slots": [],
@@ -1324,7 +1324,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided.",
+              "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided.",
               "default": "\"Close modal\"",
               "required": false
             },
@@ -1342,7 +1342,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content.",
+              "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content.",
               "default": "true",
               "required": false
             },
@@ -1715,7 +1715,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires up each time the search query changes.\r\nThe data passed is the new query."
+              "description": "Fires up each time the search query changes.\nThe data passed is the new query."
             }
           ],
           "slots": [],
@@ -2304,7 +2304,7 @@
           "kind": "class",
           "name": "dnn-vertical-splitview.tsx",
           "tagName": "dnn-vertical-splitview",
-          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
+          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
           "attributes": [
             {
               "name": "split-width-percentage",

--- a/packages/stencil-library/licenses.json
+++ b/packages/stencil-library/licenses.json
@@ -3,13 +3,6 @@
         "licenses": "MIT",
         "repository": "https://github.com/dnncommunity/dnn-elements",
         "path": "",
-        "licenseFile": "C:\\dev\\dnn-elements\\packages\\stencil-library\\README.md"
-    },
-    "typescript@5.2.2": {
-        "licenses": "Apache-2.0",
-        "repository": "https://github.com/Microsoft/TypeScript",
-        "publisher": "Microsoft Corp.",
-        "path": "node_modules\\typescript",
-        "licenseFile": "C:\\dev\\dnn-elements\\packages\\stencil-library\\node_modules\\typescript\\LICENSE.txt"
+        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\README.md"
     }
 }

--- a/packages/stencil-library/stencil.config.ts
+++ b/packages/stencil-library/stencil.config.ts
@@ -89,6 +89,33 @@ async function generateCustomElementsJson(docsData: JsonDocs) {
 
 export const config: Config = {
   namespace: 'dnn',
+  bundles: [
+    { components: ['dnn-autocomplete', 'dnn-fieldset' ]},
+    { components: ['dnn-button', 'dnn-modal']},
+    { components: ['dnn-checkbox']},
+    { components: ['dnn-chevron']},
+    { components: ['dnn-collapsible']},
+    { components: ['dnn-color-input', 'dnn-fieldset', 'dnn-modal', 'dnn-tabs', 'dnn-tab', 'dnn-color-picker', 'dnn-button']},
+    { components: ['dnn-color-picker']},
+    { components: ['dnn-dropzone']},
+    { components: ['dnn-fieldset']},
+    { components: ['dnn-image-cropper', 'dnn-dropzone', 'dnn-modal']},
+    { components: ['dnn-input', 'dnn-fieldset']},
+    { components: ['dnn-modal']},
+    { components: ['dnn-monaco-editor']},
+    { components: ['dnn-permissions-grid', 'dnn-checkbox', 'dnn-button', 'dnn-searchbox', 'dnn-collapsible']},
+    { components: ['dnn-progress-bar']},
+    { components: ['dnn-richtext']},
+    { components: ['dnn-searchbox']},
+    { components: ['dnn-select', 'dnn-fieldset']},
+    { components: ['dnn-sort-icon']},
+    { components: ['dnn-tabs', 'dnn-tab']},
+    { components: ['dnn-textarea', 'dnn-fieldset']},
+    { components: ['dnn-toggle']},
+    { components: ['dnn-treeview-item', 'dnn-collapsible']},
+    { components: ['dnn-vertical-overflow-menu']},
+    { components: ['dnn-vertical-splitview']},
+  ],
   outputTargets: [
     {
       type: 'dist',
@@ -125,5 +152,5 @@ export const config: Config = {
   sourceMap: true,
   testing: {
     browserHeadless: "new",
-  }
+  },
 };

--- a/packages/stencil-library/vscode-data.json
+++ b/packages/stencil-library/vscode-data.json
@@ -26,7 +26,7 @@
         },
         {
           "name": "preload-threshold-pixels",
-          "description": "How many suggestions to preload in pixels of their height.\r\nThis is used to calculate the virtual scroll height and request\r\nmore items before they get into view."
+          "description": "How many suggestions to preload in pixels of their height.\nThis is used to calculate the virtual scroll height and request\nmore items before they get into view."
         },
         {
           "name": "required",
@@ -34,7 +34,7 @@
         },
         {
           "name": "total-suggestions",
-          "description": "The total amount of suggestions for the given search query.\r\nThis can be used to show virtual scroll and pagination progressive feeding.\r\nThe needMoreItems event should be used to request more items."
+          "description": "The total amount of suggestions for the given search query.\nThis can be used to show virtual scroll and pagination progressive feeding.\nThe needMoreItems event should be used to request more items."
         },
         {
           "name": "value",
@@ -71,7 +71,7 @@
         },
         {
           "name": "form-button-type",
-          "description": "Optional button type,\r\ncan be either submit, reset or button and defaults to button if not specified.\r\nWarning: DNN wraps the whole page in a form, only use this if you are handling\r\nform submission manually.",
+          "description": "Optional button type,\ncan be either submit, reset or button and defaults to button if not specified.\nWarning: DNN wraps the whole page in a form, only use this if you are handling\nform submission manually.",
           "values": [
             {
               "name": "button"
@@ -105,7 +105,7 @@
         },
         {
           "name": "type",
-          "description": "Optional button style,\r\ncan be either primary, secondary or tertiary or danger and defaults to primary if not specified",
+          "description": "Optional button style,\ncan be either primary, secondary or tertiary or danger and defaults to primary if not specified",
           "values": [
             {
               "name": "danger"
@@ -276,11 +276,11 @@
       "attributes": [
         {
           "name": "allow-camera-mode",
-          "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https)."
+          "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https)."
         },
         {
           "name": "capture-quality",
-          "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8"
+          "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8"
         },
         {
           "name": "max-file-size",
@@ -361,7 +361,7 @@
       "name": "dnn-image-cropper",
       "description": {
         "kind": "markdown",
-        "value": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image."
+        "value": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image."
       },
       "attributes": [
         {
@@ -512,7 +512,7 @@
         },
         {
           "name": "close-text",
-          "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided."
+          "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided."
         },
         {
           "name": "resizable",
@@ -520,7 +520,7 @@
         },
         {
           "name": "show-close-button",
-          "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content."
+          "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content."
         },
         {
           "name": "visible",
@@ -937,7 +937,7 @@
       "name": "dnn-vertical-splitview",
       "description": {
         "kind": "markdown",
-        "value": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component."
+        "value": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component."
       },
       "attributes": [
         {


### PR DESCRIPTION
Closes #1094 

Stencil tries to intelligently decide which components should be bundled together for lazy-loading. Somehow this "intelligence" got confused and we ended up with fewer and fewer larger files along the commit history. Rading more about this, we can in the config define how we want our stuff bundled knowing which components usually are used together. The goal is to balance between multiple downloads and small downloads.

This PR manually defines bundles we want.
Examples:
1. dnn-monaco-editor has all the component code and all of monaco code in a single bundle (10.7Mb) that can be forever cached even if we do updates (as long as we don't touch that component).
2. dnn-richtext is in a bundle with all of the Jodit code together (1.1Mb)
3. dnn-color-picker is in a bundle (30Kb) has all the components that are always needed for it (buttons, modals, tabs, tab, etc.)
4. dnn-permissions gid (24Kb) has all the components used by it in the same bundle.
5. So on and so forth reducing in size up to our smallest component that can be used on its own, dnn-chevron (1Kb)