### PR TITLE
Added `focus` and `blur` logic to `dnn-autocomplete`

### DIFF
--- a/packages/stencil-library/custom-elements.json
+++ b/packages/stencil-library/custom-elements.json
@@ -99,9 +99,21 @@
             },
             {
               "kind": "method",
+              "name": "blur",
+              "description": "Removes focus from the field.",
+              "signature": "blur() => Promise<void>"
+            },
+            {
+              "kind": "method",
               "name": "checkValidity",
               "description": "Reports the input validity details. See https://developer.mozilla.org/en-US/docs/Web/API/ValidityState",
               "signature": "checkValidity() => Promise<ValidityState>"
+            },
+            {
+              "kind": "method",
+              "name": "focus",
+              "description": "Focuses the input.",
+              "signature": "focus() => Promise<void>"
             },
             {
               "kind": "method",

--- a/packages/stencil-library/src/components.d.ts
+++ b/packages/stencil-library/src/components.d.ts
@@ -34,6 +34,10 @@ export { DnnToggleChangeEventDetail } from "./components/dnn-toggle/toggle-inter
 export namespace Components {
     interface DnnAutocomplete {
         /**
+          * Removes focus from the field.
+         */
+        "blur": () => Promise<void>;
+        /**
           * Reports the input validity details. See https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
          */
         "checkValidity": () => Promise<ValidityState>;
@@ -41,6 +45,10 @@ export namespace Components {
           * Defines whether the field is disabled.
          */
         "disabled": boolean;
+        /**
+          * Focuses the input.
+         */
+        "focus": () => Promise<void>;
         /**
           * Defines the help label displayed under the field.
          */

--- a/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.tsx
+++ b/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.tsx
@@ -80,6 +80,22 @@ export class DnnAutocomplete {
     return this.inputField.setCustomValidity(message);
   }
 
+  /** Focuses the input. */
+  @Method()
+  async focus(): Promise<void> {
+    setTimeout(() => {
+      this.inputField.focus();
+    }, 0);
+  }
+
+  /** Removes focus from the field. */
+  @Method()
+  async blur(): Promise<void> {
+    setTimeout(() => {
+      this.inputField.blur();
+    }, 0);
+  }
+
   @State() focused = false;
   @State() valid = true;
   @State() customValidityMessage: string;
@@ -93,25 +109,25 @@ export class DnnAutocomplete {
   /** Listener for mouse down event */
   @Listen("click", { target: "document", capture: false })
   handleOutsideClick(e: MouseEvent) {
-    const path = e.composedPath();
-    if (!path.includes(this.element))
-      {
-        this.focused = false;
-      }
+  const path = e.composedPath();
+  if (!path.includes(this.element))
+    {
+      this.focused = false;
     }
-    
-    componentDidRender(){
-      if (this.focused && this.suggestions.length > 0 && !this.positionInitialized){
-        this.adjustDropdownPosition();
-      }
+  }
+  
+  componentDidRender(){
+    if (this.focused && this.suggestions.length > 0 && !this.positionInitialized){
+      this.adjustDropdownPosition();
     }
+  }
 
-    private inputField!: HTMLInputElement;
-    private suggestionsContainer: HTMLUListElement;
-    private labelId: string;
-    
-    // eslint-disable-next-line @stencil-community/own-methods-must-be-private
-    formResetCallback() {
+  private inputField!: HTMLInputElement;
+  private suggestionsContainer: HTMLUListElement;
+  private labelId: string;
+  
+  // eslint-disable-next-line @stencil-community/own-methods-must-be-private
+  formResetCallback() {
     this.inputField.setCustomValidity("");
     this.valid = true;
     this.value = "";
@@ -324,6 +340,7 @@ export class DnnAutocomplete {
               autoComplete="off"
               value={this.suggestions.length > 0 && this.selectedIndex != undefined ? this.suggestions[this.selectedIndex].label : this.value}
               onFocus={() => this.focused = true}
+              onBlur={() => this.focused = false}
               onInput={e => this.handleInput(e)}
               onInvalid={() => this.handleInvalid()}
               onChange={() => this.handleChange()}

--- a/packages/stencil-library/src/components/dnn-autocomplete/readme.md
+++ b/packages/stencil-library/src/components/dnn-autocomplete/readme.md
@@ -256,6 +256,16 @@ private handleLoadMore(query){
 
 ## Methods
 
+### `blur() => Promise<void>`
+
+Removes focus from the field.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 ### `checkValidity() => Promise<ValidityState>`
 
 Reports the input validity details. See https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
@@ -263,6 +273,16 @@ Reports the input validity details. See https://developer.mozilla.org/en-US/docs
 #### Returns
 
 Type: `Promise<ValidityState>`
+
+
+
+### `focus() => Promise<void>`
+
+Focuses the input.
+
+#### Returns
+
+Type: `Promise<void>`
 
 
 


### PR DESCRIPTION
This is the overall idea we need for #1055 resolution. It adds a `focus` and `blur` method to our input wrapper and forwards the behaviour to the input field we wrap. The input field itself has the logic to add/remove the focused state on the fieldset itself no matter how the focus is gained or lost.