### PR TITLE
Fixed an issue that caused label to overlay prefix/suffix

### DIFF
--- a/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
+++ b/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
@@ -172,7 +172,9 @@ export class DnnInput {
           onClick={() => !this.focused && this.inputField.focus()}
         >
           <div class="inner-container">
-            <slot name="prefix"></slot>
+            {!this.shouldLabelFloat() &&
+              <slot name="prefix"></slot>
+            }
             <input
               ref={el => this.inputField = el}
               name={this.name}
@@ -196,7 +198,9 @@ export class DnnInput {
               onChange={() => this.handleChange()}
               aria-labelledby={this.labelId}
             />
-            <slot name="suffix"></slot>
+            {!this.shouldLabelFloat() &&
+              <slot name="suffix"></slot>
+            }
             {!this.valid &&
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" class="error">
                 <path d="M479.982-280q14.018 0 23.518-9.482 9.5-9.483 9.5-23.5 0-14.018-9.482-23.518-9.483-9.5-23.5-9.5-14.018 0-23.518 9.482-9.5 9.483-9.5 23.5 0 14.018 9.482 23.518 9.483 9.5 23.5 9.5ZM453-433h60v-253h-60v253Zm27.266 353q-82.734 0-155.5-31.5t-127.266-86q-54.5-54.5-86-127.341Q80-397.681 80-480.5q0-82.819 31.5-155.659Q143-709 197.5-763t127.341-85.5Q397.681-880 480.5-880q82.819 0 155.659 31.5Q709-817 763-763t85.5 127Q880-563 880-480.266q0 82.734-31.5 155.5T763-197.684q-54 54.316-127 86Q563-80 480.266-80Zm.234-60Q622-140 721-239.5t99-241Q820-622 721.188-721 622.375-820 480-820q-141 0-240.5 98.812Q140-622.375 140-480q0 141 99.5 240.5t241 99.5Zm-.5-340Z"/>


### PR DESCRIPTION
dnn-input supports having a prefix or suffix as slots. Because the label floats as a placeholder until either the component is focused or has a value, this label could partially cover those elements.

With this PR, the prefix or suffix only show once the label slides up.

Closes #1056