### PR TITLE
Fixed an issue where inner event was fired with rich-text

### DIFF
--- a/packages/stencil-library/src/components/dnn-richtext/dnn-richtext.tsx
+++ b/packages/stencil-library/src/components/dnn-richtext/dnn-richtext.tsx
@@ -41,8 +41,8 @@ export class DnnRichtext {
     };
     this.editor = Jodit.make(this.textArea, mergedOptions);
     this.editor.value = decodeHtml(this.value);
-    this.editor.e.on('change', newValue => this.valueChange.emit(newValue));
-    this.editor.e.on('input', newValue => this.valueInput.emit(newValue));
+    this.editor.e.on('change', () => this.valueChange.emit(this.editor.value));
+    this.editor.e.on('input', () => this.valueInput.emit(this.editor.value));
   }
 
   render() {


### PR DESCRIPTION
The valueChange and valueInput events were firing the Jodit inner events instead of the value strings.

Closes #1156 