### PR TITLE
Fixed an issue where label would cover text in dnn-autocomplete

### DIFF
--- a/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.tsx
+++ b/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.tsx
@@ -130,6 +130,7 @@ export class DnnAutocomplete {
   
   private handleInput(e: Event) {
     const value = (e.target as HTMLInputElement).value;
+    this.value = value;
     var valid = this.inputField.checkValidity();
     this.valid = valid;
     this.valueInput.emit(value);
@@ -225,7 +226,7 @@ export class DnnAutocomplete {
         this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
       }
     }
-    this.value = this.suggestions[this.selectedIndex]?.value;
+    this.value = this.suggestions[this.selectedIndex]?.value || this.value;
     if (e.key === "Enter") {
       var selectedItem = this.suggestions[this.selectedIndex];
       this.value = selectedItem.value;

--- a/packages/stencil-library/src/components/dnn-textarea/dnn-textarea.tsx
+++ b/packages/stencil-library/src/components/dnn-textarea/dnn-textarea.tsx
@@ -84,6 +84,9 @@ export class DnnTextarea {
 
   componentWillLoad() {
     this.labelId = generateRandomId();
+  }
+
+  componentDidLoad() {
     this.textarea.style.minHeight = `${this.rows * 1.5}em`;
   }
 


### PR DESCRIPTION
Closes #1181

![image](https://github.com/user-attachments/assets/390b2f31-ea80-4059-bc69-dfc6c0da22c9)


Also, the height adjustment in the previous PR for textarea was in the wrong lifecycle event as we need the elements to exist before setting styles to them directly.