### PR TITLE
Fixed an issue with 0 string float label

### DIFF
--- a/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
+++ b/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
@@ -184,7 +184,7 @@ export class DnnInput {
       return false;
     }
 
-    if (this.type === "number" && this.value === 0){
+    if (this.value === 0){
       return false;
     }
     

--- a/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
+++ b/packages/stencil-library/src/components/dnn-input/dnn-input.tsx
@@ -184,7 +184,7 @@ export class DnnInput {
       return false;
     }
 
-    if (this.value === 0){
+    if (this.value == 0){
       return false;
     }
     


### PR DESCRIPTION
What was corrected in #1212 only handled the input being of type "number" but having the string "0" also caused the label issue. This PR fixes that.