### PR TITLE
Updated border and background color for `dnn-dropzone` for compatibility with DNN 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22489,9 +22489,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -23701,7 +23701,7 @@
         "react-dom": "^18.2.0",
         "rollup-plugin-node-polyfills": "^0.2.1",
         "storybook": "^8.3.2",
-        "typescript": "5.6.3",
+        "typescript": "5.7.2",
         "typescript-debounce-decorator": "^0.0.18"
       }
     },

--- a/packages/stencil-library/custom-elements.json
+++ b/packages/stencil-library/custom-elements.json
@@ -16,7 +16,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Defines the type of automatic completion the browser could use.\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete",
+              "description": "Defines the type of automatic completion the browser could use.\r\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete",
               "default": "\"off\"",
               "required": false
             },
@@ -57,7 +57,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "How many suggestions to preload in pixels of their height.\nThis is used to calculate the virtual scroll height and request\nmore items before they get into view.",
+              "description": "How many suggestions to preload in pixels of their height.\r\nThis is used to calculate the virtual scroll height and request\r\nmore items before they get into view.",
               "default": "1000",
               "required": false
             },
@@ -74,7 +74,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "The total amount of suggestions for the given search query.\nThis can be used to show virtual scroll and pagination progressive feeding.\nThe needMoreItems event should be used to request more items.",
+              "description": "The total amount of suggestions for the given search query.\r\nThis can be used to show virtual scroll and pagination progressive feeding.\r\nThe needMoreItems event should be used to request more items.",
               "required": false
             },
             {
@@ -139,7 +139,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires when the search query has changed.\nThis is almost like valueInput, but it is debounced\nand can be used to trigger a search query without overloading\nAPI endpoints while typing."
+              "description": "Fires when the search query has changed.\r\nThis is almost like valueInput, but it is debounced\r\nand can be used to trigger a search query without overloading\r\nAPI endpoints while typing."
             },
             {
               "name": "valueChange",
@@ -252,7 +252,7 @@
               "type": {
                 "text": "\"button\" | \"reset\" | \"submit\""
               },
-              "description": "Optional button type,\ncan be either submit, reset or button and defaults to button if not specified.\nWarning: DNN wraps the whole page in a form, only use this if you are handling\nform submission manually.\nWarning: This will be deprecated in the next version and replaced with a new 'type' property.",
+              "description": "Optional button type,\r\ncan be either submit, reset or button and defaults to button if not specified.\r\nWarning: DNN wraps the whole page in a form, only use this if you are handling\r\nform submission manually.\r\nWarning: This will be deprecated in the next version and replaced with a new 'type' property.",
               "default": "'button'",
               "required": false
             },
@@ -390,7 +390,7 @@
               "type": {
                 "text": "(currentState: CheckedState) => CheckedState"
               },
-              "description": "A function that will be called when the checkbox needs to change state and returns the next state.\nCan be used to customize the order of the states when the component is clicked.\nOnly called if you also use the tri-state feature (useIntermediate).",
+              "description": "A function that will be called when the checkbox needs to change state and returns the next state.\r\nCan be used to customize the order of the states when the component is clicked.\r\nOnly called if you also use the tri-state feature (useIntermediate).",
               "default": "this.defaultNextStateHandler",
               "required": false
             }
@@ -645,7 +645,7 @@
                 "text": "{ contrast: string; preview: string; cancel: string; confirm: string; normal: string; light: string; dark: string; }"
               },
               "description": "Can be used to customize the text language.",
-              "default": "{\n    contrast: \"Contrast\",\n    preview: \"Preview\",\n    cancel: \"Cancel\",\n    confirm: \"Confirm\",\n    normal: \"Normal\",\n    light: \"Light\",\n    dark: \"Dark\",\n  }",
+              "default": "{\r\n    contrast: \"Contrast\",\r\n    preview: \"Preview\",\r\n    cancel: \"Cancel\",\r\n    confirm: \"Confirm\",\r\n    normal: \"Normal\",\r\n    light: \"Light\",\r\n    dark: \"Dark\",\r\n  }",
               "required": false
             }
           ],
@@ -761,7 +761,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https).",
+              "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https).",
               "default": "false",
               "required": false
             },
@@ -770,7 +770,7 @@
               "type": {
                 "text": "number"
               },
-              "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8",
+              "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8",
               "default": "0.8",
               "required": false
             },
@@ -798,7 +798,7 @@
               "type": {
                 "text": "string[]"
               },
-              "description": "A list of allowed file extensions.\nIf not specified, any file is allowed.\nEx: [\"jpg\", \"jpeg\", \"gif\", \"png\"]",
+              "description": "A list of allowed file extensions.\r\nIf not specified, any file is allowed.\r\nEx: [\"jpg\", \"jpeg\", \"gif\", \"png\"]",
               "required": false
             },
             {
@@ -1014,7 +1014,7 @@
           "kind": "class",
           "name": "dnn-image-cropper.tsx",
           "tagName": "dnn-image-cropper",
-          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image.",
+          "description": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image.",
           "attributes": [
             {
               "name": "height",
@@ -1066,7 +1066,7 @@
               "type": {
                 "text": "ImageCropperResx"
               },
-              "description": "Can be used to customize controls text.\nSome values support tokens, see default values for examples.",
+              "description": "Can be used to customize controls text.\r\nSome values support tokens, see default values for examples.",
               "required": false
             },
             {
@@ -1089,7 +1089,7 @@
               "type": {
                 "text": "File"
               },
-              "description": "Emits both when a file is initially select and when the crop has changed.\nCompared to imageCropChanged, this event emits the file itself, which can be useful for uploading the file to a server including its name."
+              "description": "Emits both when a file is initially select and when the crop has changed.\r\nCompared to imageCropChanged, this event emits the file itself, which can be useful for uploading the file to a server including its name."
             }
           ],
           "slots": [],
@@ -1154,7 +1154,7 @@
               "type": {
                 "text": "\"decimal\" | \"email\" | \"none\" | \"numeric\" | \"search\" | \"tel\" | \"text\" | \"url\""
               },
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
               "required": false
             },
             {
@@ -1357,7 +1357,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided.",
+              "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided.",
               "default": "\"Close modal\"",
               "required": false
             },
@@ -1375,7 +1375,7 @@
               "type": {
                 "text": "boolean"
               },
-              "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content.",
+              "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content.",
               "default": "true",
               "required": false
             },
@@ -1677,7 +1677,7 @@
               "type": {
                 "text": "(options: Config) => Config"
               },
-              "description": "Customize the options before initializing the editor, will have all the default options merged with 'options' if passed.\nThis is called last after merging default options with your custom 'options' and just before initializing the editor.",
+              "description": "Customize the options before initializing the editor, will have all the default options merged with 'options' if passed.\r\nThis is called last after merging default options with your custom 'options' and just before initializing the editor.",
               "required": false
             },
             {
@@ -1686,7 +1686,7 @@
               "type": {
                 "text": "Config"
               },
-              "description": "Optional configuration for Jodit, see https://xdsoft.net/jodit/docs/classes/config.Config.html\nThis will be merged with the default options and passed to the editor.\nIf you prefer to not have to pass a full config object,\nyou can use 'customizeOptions' to modify the options before initializing the editor\ninstead of providing all options here.",
+              "description": "Optional configuration for Jodit, see https://xdsoft.net/jodit/docs/classes/config.Config.html\r\nThis will be merged with the default options and passed to the editor.\r\nIf you prefer to not have to pass a full config object,\r\nyou can use 'customizeOptions' to modify the options before initializing the editor\r\ninstead of providing all options here.",
               "required": false
             },
             {
@@ -1695,7 +1695,7 @@
               "type": {
                 "text": "{ name: string; callback: (editor: Jodit) => void; }[]"
               },
-              "description": "Allows registering your own plugins.\nThe callback will be called with the editor instance as the only argument durig initialization.\nAll other behavior needs to be implemented in the plugin itself using editor.on(\"eventname\").\nSee https://xdsoft.net/jodit/examples/plugin/custom_plugin.html for an example.\nCreating a plugin does NOT automatically add it to the toolbar, you need to do that yourself in 'options' or 'customizeOptions',\nSee https://xdsoft.net/jodit/examples/toolbar/custom_button.html for an example.",
+              "description": "Allows registering your own plugins.\r\nThe callback will be called with the editor instance as the only argument durig initialization.\r\nAll other behavior needs to be implemented in the plugin itself using editor.on(\"eventname\").\r\nSee https://xdsoft.net/jodit/examples/plugin/custom_plugin.html for an example.\r\nCreating a plugin does NOT automatically add it to the toolbar, you need to do that yourself in 'options' or 'customizeOptions',\r\nSee https://xdsoft.net/jodit/examples/toolbar/custom_button.html for an example.",
               "default": "[]",
               "required": false
             }
@@ -1776,7 +1776,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Fires up each time the search query changes.\nThe data passed is the new query."
+              "description": "Fires up each time the search query changes.\r\nThe data passed is the new query."
             }
           ],
           "slots": [],
@@ -1800,7 +1800,7 @@
               "type": {
                 "text": "string"
               },
-              "description": "Defines the type of automatic completion the browser can use.\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete",
+              "description": "Defines the type of automatic completion the browser can use.\r\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete",
               "default": "\"off\"",
               "required": false
             },
@@ -2383,7 +2383,7 @@
           "kind": "class",
           "name": "dnn-vertical-splitview.tsx",
           "tagName": "dnn-vertical-splitview",
-          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
+          "description": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component.",
           "attributes": [
             {
               "name": "split-width-percentage",

--- a/packages/stencil-library/licenses.json
+++ b/packages/stencil-library/licenses.json
@@ -3,7 +3,7 @@
         "licenses": "MIT",
         "repository": "https://github.com/dnncommunity/dnn-elements",
         "path": "",
-        "licenseFile": "D:\\dnn-elements\\dnn-elements\\packages\\stencil-library\\README.md"
+        "licenseFile": "C:\\dev\\dnn-elements\\packages\\stencil-library\\README.md"
     },
     "@storybook/theming@8.3.2": {
         "licenses": "MIT",

--- a/packages/stencil-library/src/components/dnn-dropzone/dnn-dropzone.scss
+++ b/packages/stencil-library/src/components/dnn-dropzone/dnn-dropzone.scss
@@ -5,9 +5,9 @@
   * @prop --border-radius: The radius of the controls borders.
   * @prop --drop-background-color: The color of the background when a file is dropping.
   */
-  --border-color: var(--dnn-color-tertiary-contrast, lightgray);
+  --border-color: var(--dnn-color-foreground-light, lightgray);
   --border-radius: var(--dnn-controls-radius, 5px);
-  --drop-background-color: var(--dnn-color-tertiary, lightblue);
+  --drop-background-color: var(--dnn-color-neutral, #b2b2b2);
 
   display: flex;
   flex-direction: column;

--- a/packages/stencil-library/vscode-data.json
+++ b/packages/stencil-library/vscode-data.json
@@ -10,7 +10,7 @@
       "attributes": [
         {
           "name": "autocomplete",
-          "description": "Defines the type of automatic completion the browser could use.\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"
+          "description": "Defines the type of automatic completion the browser could use.\r\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"
         },
         {
           "name": "disabled",
@@ -30,7 +30,7 @@
         },
         {
           "name": "preload-threshold-pixels",
-          "description": "How many suggestions to preload in pixels of their height.\nThis is used to calculate the virtual scroll height and request\nmore items before they get into view."
+          "description": "How many suggestions to preload in pixels of their height.\r\nThis is used to calculate the virtual scroll height and request\r\nmore items before they get into view."
         },
         {
           "name": "required",
@@ -38,7 +38,7 @@
         },
         {
           "name": "total-suggestions",
-          "description": "The total amount of suggestions for the given search query.\nThis can be used to show virtual scroll and pagination progressive feeding.\nThe needMoreItems event should be used to request more items."
+          "description": "The total amount of suggestions for the given search query.\r\nThis can be used to show virtual scroll and pagination progressive feeding.\r\nThe needMoreItems event should be used to request more items."
         },
         {
           "name": "value",
@@ -93,7 +93,7 @@
         },
         {
           "name": "form-button-type",
-          "description": "Optional button type,\ncan be either submit, reset or button and defaults to button if not specified.\nWarning: DNN wraps the whole page in a form, only use this if you are handling\nform submission manually.\nWarning: This will be deprecated in the next version and replaced with a new 'type' property.",
+          "description": "Optional button type,\r\ncan be either submit, reset or button and defaults to button if not specified.\r\nWarning: DNN wraps the whole page in a form, only use this if you are handling\r\nform submission manually.\r\nWarning: This will be deprecated in the next version and replaced with a new 'type' property.",
           "values": [
             {
               "name": "button"
@@ -298,11 +298,11 @@
       "attributes": [
         {
           "name": "allow-camera-mode",
-          "description": "If true, will allow the user to take a snapshot\nusing the device camera. (only works over https)."
+          "description": "If true, will allow the user to take a snapshot\r\nusing the device camera. (only works over https)."
         },
         {
           "name": "capture-quality",
-          "description": "Specifies the jpeg quality for when the device\ncamera is used to generate a picture.\nNeeds to be a number between 0 and 1 and defaults to 0.8"
+          "description": "Specifies the jpeg quality for when the device\r\ncamera is used to generate a picture.\r\nNeeds to be a number between 0 and 1 and defaults to 0.8"
         },
         {
           "name": "max-file-size",
@@ -383,7 +383,7 @@
       "name": "dnn-image-cropper",
       "description": {
         "kind": "markdown",
-        "value": "Allows cropping an image in-browser with the option to enforce a specific final size.\nAll computation happens in the browser and the final image is emmited\nin an event that has a data-url of the image."
+        "value": "Allows cropping an image in-browser with the option to enforce a specific final size.\r\nAll computation happens in the browser and the final image is emmited\r\nin an event that has a data-url of the image."
       },
       "attributes": [
         {
@@ -437,7 +437,7 @@
         },
         {
           "name": "inputmode",
-          "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+          "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
           "values": [
             {
               "name": "decimal"
@@ -564,7 +564,7 @@
         },
         {
           "name": "close-text",
-          "description": "Optionally pass the aria-label text for the close button.\nDefaults to \"Close modal\" if not provided."
+          "description": "Optionally pass the aria-label text for the close button.\r\nDefaults to \"Close modal\" if not provided."
         },
         {
           "name": "resizable",
@@ -572,7 +572,7 @@
         },
         {
           "name": "show-close-button",
-          "description": "Optionally you can pass false to not show the close button.\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\nor provide your own dismissal logic in the modal content."
+          "description": "Optionally you can pass false to not show the close button.\r\nIf you decide to do so, you should either not also prevent dismissal by clicking the backdrop\r\nor provide your own dismissal logic in the modal content."
         },
         {
           "name": "visible",
@@ -797,7 +797,7 @@
       "attributes": [
         {
           "name": "autocomplete",
-          "description": "Defines the type of automatic completion the browser can use.\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"
+          "description": "Defines the type of automatic completion the browser can use.\r\nSee https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete"
         },
         {
           "name": "disable-validity-reporting",
@@ -1001,7 +1001,7 @@
       "name": "dnn-vertical-splitview",
       "description": {
         "kind": "markdown",
-        "value": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\n- The content for the left part should be injected in the `left` slot.\n- The content for the right part should be injected in the `right` slot.\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component."
+        "value": "This allows splitting a UI into vertical adjustable panels, the splitter itself is not part of this component.\r\n- The content for the left part should be injected in the `left` slot.\r\n- The content for the right part should be injected in the `right` slot.\r\n- The content for the actual splitter should go in the default slot and other UI elements can be injected as long as you handle their behaviour, by default only the drag behavior is implemented in the component."
       },
       "attributes": [
         {


### PR DESCRIPTION
Updated border and background color for `dnn-dropzone` for compatibility with DNN 10.  The screenshots below are based on the DNN CSS variables hard-coded in `index.html` so there may be a slight variation between them and what is actually in DNN 10.  We may want to consider updating these in DNN elements to match DNN 10 now that it has been implemented in DNN 10.

![image](https://github.com/user-attachments/assets/2d943eb4-20a0-4d6d-8630-9fe37b769116)

![image](https://github.com/user-attachments/assets/ae2d9277-8de8-4858-9079-f1a5e8d88990)

Resolves #1246 
