### PR TITLE
Fixed some issues with css-variables of inputs

### DIFF
--- a/packages/stencil-library/custom-elements.json
+++ b/packages/stencil-library/custom-elements.json
@@ -677,7 +677,7 @@
           ],
           "cssProperties": [
             {
-              "name": "--background",
+              "name": "--background-color",
               "description": "Defines the background color."
             },
             {
@@ -693,7 +693,7 @@
               "description": "Defines the color when the component is focused."
             },
             {
-              "name": "--foreground",
+              "name": "--foreground-color",
               "description": "Defines the foreground color."
             }
           ],
@@ -982,10 +982,6 @@
           ],
           "cssProperties": [
             {
-              "name": "--background",
-              "description": "Defines the background color."
-            },
-            {
               "name": "--control-radius",
               "description": "Defines the radius for the control corners."
             },
@@ -994,12 +990,16 @@
               "description": "Defines the danger color used for invalid data."
             },
             {
-              "name": "--focus-color",
-              "description": "Defines the color when the component is focused."
+              "name": "--fieldset-background-color",
+              "description": "Defines the background color."
             },
             {
-              "name": "--foreground",
+              "name": "--fieldset-foreground-color",
               "description": "Defines the foreground color."
+            },
+            {
+              "name": "--focus-color",
+              "description": "Defines the color when the component is focused."
             }
           ],
           "cssParts": []
@@ -1305,7 +1305,7 @@
           ],
           "cssProperties": [
             {
-              "name": "--background",
+              "name": "--background-color",
               "description": "Defines the background color."
             },
             {
@@ -1321,7 +1321,7 @@
               "description": "Defines the color when the component is focused."
             },
             {
-              "name": "--foreground",
+              "name": "--foreground-color",
               "description": "Defines the foreground color."
             },
             {
@@ -1862,7 +1862,7 @@
           "slots": [],
           "cssProperties": [
             {
-              "name": "--background",
+              "name": "--background-color",
               "description": "Defines the background color."
             },
             {
@@ -1878,7 +1878,7 @@
               "description": "Defines the color when the component is focused."
             },
             {
-              "name": "--foreground",
+              "name": "--foreground-color",
               "description": "Defines the foreground color."
             },
             {
@@ -2161,7 +2161,7 @@
           "slots": [],
           "cssProperties": [
             {
-              "name": "--background",
+              "name": "--background-color",
               "description": "Defines the background color."
             },
             {
@@ -2177,7 +2177,7 @@
               "description": "Defines the color when the component is focused."
             },
             {
-              "name": "--foreground",
+              "name": "--foreground-color",
               "description": "Defines the foreground color."
             }
           ],

--- a/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.scss
+++ b/packages/stencil-library/src/components/dnn-autocomplete/dnn-autocomplete.scss
@@ -52,6 +52,7 @@ dnn-fieldset{
     height: 1rem;
     width: auto;
     transform: scale(1.2);
+    fill: var(--foreground-color);
     cursor: pointer;
   }
 
@@ -99,4 +100,12 @@ dnn-fieldset{
       opacity: 0.5;
     }
   }
+}
+
+dnn-fieldset{
+  --fieldset-foreground-color: var(--foreground-color);
+  --fieldset-background-color: var(--background-color);
+  --fieldset-focus-color: var(--focus-color);
+  --fieldset-danger-color: var(--danger-color);
+  --fieldset-control-radius: var(--control-radius);
 }

--- a/packages/stencil-library/src/components/dnn-color-input/dnn-color-input.scss
+++ b/packages/stencil-library/src/components/dnn-color-input/dnn-color-input.scss
@@ -1,11 +1,11 @@
 :host {
   display: inline-block;
 
-  /** @prop --foreground: Defines the foreground color. */
-  --foreground: var(--dnn-color-foreground, #000);
+  /** @prop --foreground-color: Defines the foreground color. */
+  --foreground-color: var(--dnn-color-foreground, #000);
 
-  /** @prop --background: Defines the background color. */
-  --background: var(--dnn-color-background, #fff);
+  /** @prop --background-color: Defines the background color. */
+  --background-color: var(--dnn-color-background, #fff);
 
   /** @prop --focus-color: Defines the color when the component is focused. */
   --focus-color: var(--dnn-color-primary, #3792ED);
@@ -25,7 +25,7 @@ dnn-fieldset{
   justify-content: space-between;
   position: relative;
   width: 100%;
-  background-color: var(--background);
+  background-color: var(--background-color);
 }
 
 button{
@@ -79,4 +79,12 @@ h3{
   display: flex;
   justify-content: space-between;
   margin-top: 1em;
+}
+
+dnn-fieldset{
+  --fieldset-foreground-color: var(--foreground-color);
+  --fieldset-background-color: var(--background-color);
+  --fieldset-focus-color: var(--focus-color);
+  --fieldset-danger-color: var(--danger-color);
+  --fieldset-control-radius: var(--control-radius);
 }

--- a/packages/stencil-library/src/components/dnn-color-input/readme.md
+++ b/packages/stencil-library/src/components/dnn-color-input/readme.md
@@ -47,11 +47,11 @@ A custom input component that allows previewing and changing a color value.
 
 | Name                   | Description                                                          |
 | ---------------------- | -------------------------------------------------------------------- |
-| `--background`         | Defines the background color.                                        |
+| `--background-color`   | Defines the background color.                                        |
 | `--contast-text-align` | Allows customizing the text alignment of the contast indicator text. |
 | `--control-radius`     | Defines the radius for the control corners.                          |
 | `--focus-color`        | Defines the color when the component is focused.                     |
-| `--foreground`         | Defines the foreground color.                                        |
+| `--foreground-color`   | Defines the foreground color.                                        |
 
 
 ## Dependencies

--- a/packages/stencil-library/src/components/dnn-fieldset/dnn-fieldset.scss
+++ b/packages/stencil-library/src/components/dnn-fieldset/dnn-fieldset.scss
@@ -1,11 +1,11 @@
 :host {
   display: inline-block;
 
-  /** @prop --foreground: Defines the foreground color. */
-  --fieldset-foreground: var(--dnn-color-foreground, #000);
+  /** @prop --fieldset-foreground-color: Defines the foreground color. */
+  --fieldset-foreground-color: var(--dnn-color-foreground, #000);
 
-  /** @prop --background: Defines the background color. */
-  --fieldset-background: var(--dnn-color-background, #fff);
+  /** @prop --fieldset-background-color: Defines the background color. */
+  --fieldset-background-color: var(--dnn-color-background, #fff);
 
   /** @prop --focus-color: Defines the color when the component is focused. */
   --fieldset-focus-color: var(--dnn-color-primary, #3792ED);
@@ -18,14 +18,14 @@
 }
 
 .container{
-  border: 1px solid var(--fieldset-foreground, #000);
+  border: 1px solid var(--fieldset-foreground-color, #000);
   border-radius: var(--fieldset-control-radius, 3px);
   padding: 0.75em;
   display: flex;
   justify-content: space-between;
   gap: 0.1em;
   position: relative;
-  background-color: var(--fieldset-background);
+  background-color: var(--fieldset-background-color);
   margin-top: 1em;
   line-height: 1em;
   .resizer{
@@ -34,7 +34,7 @@
   .inner-container{
     position: relative;
     width: 100%;
-    background-color: var(--fieldset-background);
+    background-color: var(--fieldset-background-color);
     height: calc(100% - 1em);
   }
   label{
@@ -45,7 +45,7 @@
     left: 0.5em;
     top: -1.5em;
     padding: 0 0.5em;
-    background-color: var(--fieldset-background);
+    background-color: var(--fieldset-background-color);
     white-space: nowrap;
     max-width: 100%;
     border-radius: var(--fieldset-control-radius);
@@ -63,7 +63,7 @@
       box-shadow: 0 0 0 1px var(--fieldset-danger-color);
     }
     input{
-      color: var(--fieldset-foreground, #000);
+      color: var(--fieldset-foreground-color, #000);
     }
   }
   &.float-label{

--- a/packages/stencil-library/src/components/dnn-fieldset/readme.md
+++ b/packages/stencil-library/src/components/dnn-fieldset/readme.md
@@ -112,13 +112,13 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name               | Description                                      |
-| ------------------ | ------------------------------------------------ |
-| `--background`     | Defines the background color.                    |
-| `--control-radius` | Defines the radius for the control corners.      |
-| `--danger-color`   | Defines the danger color used for invalid data.  |
-| `--focus-color`    | Defines the color when the component is focused. |
-| `--foreground`     | Defines the foreground color.                    |
+| Name                          | Description                                      |
+| ----------------------------- | ------------------------------------------------ |
+| `--control-radius`            | Defines the radius for the control corners.      |
+| `--danger-color`              | Defines the danger color used for invalid data.  |
+| `--fieldset-background-color` | Defines the background color.                    |
+| `--fieldset-foreground-color` | Defines the foreground color.                    |
+| `--focus-color`               | Defines the color when the component is focused. |
 
 
 ## Dependencies

--- a/packages/stencil-library/src/components/dnn-input/dnn-input.scss
+++ b/packages/stencil-library/src/components/dnn-input/dnn-input.scss
@@ -1,11 +1,11 @@
 :host {
   display: inline-block;
 
-  /** @prop --foreground: Defines the foreground color. */
-  --foreground: var(--dnn-color-foreground, #000);
+  /** @prop --foreground-color: Defines the foreground color. */
+  --foreground-color: var(--dnn-color-foreground, #000);
 
-  /** @prop --background: Defines the background color. */
-  --background: var(--dnn-color-background, #fff);
+  /** @prop --background-color: Defines the background color. */
+  --background-color: var(--dnn-color-background, #fff);
 
   /** @prop --focus-color: Defines the color when the component is focused. */
   --focus-color: var(--dnn-color-primary, #3792ED);
@@ -62,4 +62,12 @@ button.show-password{
     fill: var(--foreground);
     transform: scale(1.5);
   }
+}
+
+dnn-fieldset{
+  --fieldset-foreground-color: var(--foreground-color);
+  --fieldset-background-color: var(--background-color);
+  --fieldset-focus-color: var(--focus-color);
+  --fieldset-danger-color: var(--danger-color);
+  --fieldset-control-radius: var(--control-radius);
 }

--- a/packages/stencil-library/src/components/dnn-input/readme.md
+++ b/packages/stencil-library/src/components/dnn-input/readme.md
@@ -83,11 +83,11 @@ Type: `Promise<void>`
 
 | Name                 | Description                                              |
 | -------------------- | -------------------------------------------------------- |
-| `--background`       | Defines the background color.                            |
+| `--background-color` | Defines the background color.                            |
 | `--control-radius`   | Defines the radius for the control corners.              |
 | `--danger-color`     | Defines the danger color used for invalid data.          |
 | `--focus-color`      | Defines the color when the component is focused.         |
-| `--foreground`       | Defines the foreground color.                            |
+| `--foreground-color` | Defines the foreground color.                            |
 | `--input-text-align` | Allows customizing the text alignment of the input text. |
 
 

--- a/packages/stencil-library/src/components/dnn-select/dnn-select.scss
+++ b/packages/stencil-library/src/components/dnn-select/dnn-select.scss
@@ -36,7 +36,7 @@ select{
   border: none;
   outline: none;
   background-color: var(--background-color);
-  color: var(--foreground);
+  color: var(--foreground-color);
   text-align: var(--input-text-align);
   width: 100%;
   cursor: pointer; 

--- a/packages/stencil-library/src/components/dnn-select/dnn-select.scss
+++ b/packages/stencil-library/src/components/dnn-select/dnn-select.scss
@@ -1,11 +1,11 @@
 :host {
   display: inline-block;
 
-  /** @prop --foreground: Defines the foreground color. */
-  --foreground: var(--dnn-color-foreground, #000);
+  /** @prop --foreground-color: Defines the foreground color. */
+  --foreground-color: var(--dnn-color-foreground, #000);
 
-  /** @prop --background: Defines the background color. */
-  --background: var(--dnn-color-background, #fff);
+  /** @prop --background-color: Defines the background color. */
+  --background-color: var(--dnn-color-background, #fff);
 
   /** @prop --focus-color: Defines the color when the component is focused. */
   --focus-color: var(--dnn-color-primary, #3792ED);
@@ -29,13 +29,14 @@ dnn-fieldset{
   justify-content: space-between;
   position: relative;
   width: 100%;
-  background-color: var(--background);
+  background-color: var(--background-color);
 }
 
 select{
   border: none;
   outline: none;
-  background-color: var(--background);
+  background-color: var(--background-color);
+  color: var(--foreground);
   text-align: var(--input-text-align);
   width: 100%;
   cursor: pointer; 
@@ -51,4 +52,12 @@ svg{
     height: 1em;
     transform: scale(1.5);
   }
+}
+
+dnn-fieldset{
+  --fieldset-foreground-color: var(--foreground-color);
+  --fieldset-background-color: var(--background-color);
+  --fieldset-focus-color: var(--focus-color);
+  --fieldset-danger-color: var(--danger-color);
+  --fieldset-control-radius: var(--control-radius);
 }

--- a/packages/stencil-library/src/components/dnn-select/readme.md
+++ b/packages/stencil-library/src/components/dnn-select/readme.md
@@ -43,11 +43,11 @@ Type: `Promise<ValidityState>`
 
 | Name                 | Description                                              |
 | -------------------- | -------------------------------------------------------- |
-| `--background`       | Defines the background color.                            |
+| `--background-color` | Defines the background color.                            |
 | `--control-radius`   | Defines the radius for the control corners.              |
 | `--danger-color`     | Defines the danger color used for invalid data.          |
 | `--focus-color`      | Defines the color when the component is focused.         |
-| `--foreground`       | Defines the foreground color.                            |
+| `--foreground-color` | Defines the foreground color.                            |
 | `--input-text-align` | Allows customizing the text alignment of the input text. |
 
 

--- a/packages/stencil-library/src/components/dnn-textarea/dnn-textarea.scss
+++ b/packages/stencil-library/src/components/dnn-textarea/dnn-textarea.scss
@@ -1,11 +1,11 @@
 :host {
   display: inline-block;
 
-    /** @prop --foreground: Defines the foreground color. */
-    --foreground: var(--dnn-color-foreground, #000);
+    /** @prop --foreground-color: Defines the foreground color. */
+    --foreground-color: var(--dnn-color-foreground, #000);
 
-    /** @prop --background: Defines the background color. */
-    --background: var(--dnn-color-background, #fff);
+    /** @prop --background-color: Defines the background color. */
+    --background-color: var(--dnn-color-background, #fff);
   
     /** @prop --focus-color: Defines the color when the component is focused. */
     --focus-color: var(--dnn-color-primary, #3792ED);
@@ -25,9 +25,17 @@ textarea{
   border: none;
   outline: none;
   background-color: transparent;
-  color: var(--foreground);
+  color: var(--foreground-color);
   width: calc(100% - 1em);
   height: calc(100% - 1em);
   line-height: 1.5em;
   resize: none;
+}
+
+dnn-fieldset{
+  --fieldset-foreground-color: var(--foreground-color);
+  --fieldset-background-color: var(--background-color);
+  --fieldset-focus-color: var(--focus-color);
+  --fieldset-danger-color: var(--danger-color);
+  --fieldset-control-radius: var(--control-radius);
 }

--- a/packages/stencil-library/src/components/dnn-textarea/readme.md
+++ b/packages/stencil-library/src/components/dnn-textarea/readme.md
@@ -66,13 +66,13 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name               | Description                                      |
-| ------------------ | ------------------------------------------------ |
-| `--background`     | Defines the background color.                    |
-| `--control-radius` | Defines the radius for the control corners.      |
-| `--danger-color`   | Defines the danger color used for invalid data.  |
-| `--focus-color`    | Defines the color when the component is focused. |
-| `--foreground`     | Defines the foreground color.                    |
+| Name                 | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| `--background-color` | Defines the background color.                    |
+| `--control-radius`   | Defines the radius for the control corners.      |
+| `--danger-color`     | Defines the danger color used for invalid data.  |
+| `--focus-color`      | Defines the color when the component is focused. |
+| `--foreground-color` | Defines the foreground color.                    |
 
 
 ## Dependencies


### PR DESCRIPTION
We created a way for people to be able to customize styles of input elements with some css-variables, however some of the variables defined were not being passed down to the wrapping fieldset causing confusion.

Also the namin of those variables was a bit different from component to component, this PR also harmonizes that naming for avoiding further confusion. This rename is a slight breaking change, so I'll call attention to it in the release notes.

Example of some custom usage on a dark theme:
![image](https://github.com/user-attachments/assets/edd0f043-7b76-454c-9770-8591a67544cc)

Closes #1251 