### PR TITLE
Fixed an issue where dnn-select was not being properly initialized

### DIFF
--- a/packages/stencil-library/src/components/dnn-button/dnn-button.tsx
+++ b/packages/stencil-library/src/components/dnn-button/dnn-button.tsx
@@ -120,6 +120,8 @@ export class DnnButton {
         }
         else
         {
+          const invalidEvent = new window.Event('invalid', { bubbles: true, cancelable: true });
+          form.dispatchEvent(invalidEvent);
           var formControls = form.elements;
           for (let i = 0; i < formControls.length; i++){
             var control = formControls[i] as HTMLFormElement;

--- a/packages/stencil-library/src/components/dnn-select/dnn-select.tsx
+++ b/packages/stencil-library/src/components/dnn-select/dnn-select.tsx
@@ -61,7 +61,6 @@ export class DnnSelect {
   private originalValue!: string;
   
   componentWillLoad() {
-    this.originalValue = this.value;
     this.labelId = generateRandomId();
     this.observer = new MutationObserver((mutations) => {
       for (let mutation of mutations) {
@@ -77,11 +76,24 @@ export class DnnSelect {
   
   componentDidLoad() {
     requestAnimationFrame(() => {
+      this.applySlottedItemsToSelect();
+      
+      // Initialize value based on the "selected" attribute of slotted options
+      const slottedItems = this.el.querySelectorAll('option');
+      const selectedOption = Array.from(slottedItems).find(option => option.hasAttribute('selected'));
+      if (selectedOption) {
+        this.value = selectedOption.getAttribute('value') || selectedOption.textContent || '';
+      } else if (slottedItems.length > 0) {
+        this.value = slottedItems[0].getAttribute('value') || slottedItems[0].textContent || '';
+      }
+
+      // Set the original value for form reset
+      this.originalValue = this.value;
       var validity = this.select.validity;
       var validityMessage = validity.valid ? "" : this.select.validationMessage;
       this.internals.setValidity(this.select.validity, validityMessage);
-      this.applySlottedItemsToSelect();
       this.setFormValue();
+
     });
   }
    

--- a/packages/stencil-library/src/components/examples/dnn-example-form/dnn-example-form.tsx
+++ b/packages/stencil-library/src/components/examples/dnn-example-form/dnn-example-form.tsx
@@ -151,6 +151,18 @@ export class DnnExampleForm {
           <button onClick={() => this.fieldset.unpinLabel()}>Unpin Label</button>
         </dnn-fieldset>
         <form
+          onError={e => console.error(e)}
+          onInvalid={e => {
+            e.preventDefault();
+            console.group("Form invalid");
+            const form = e.target as HTMLFormElement;
+            const invalidControls = form.querySelectorAll<HTMLElement>(":invalid");
+            invalidControls.forEach(control => {
+              const validityState = (control as HTMLInputElement).validity;
+              console.log(control, validityState);
+            });
+            console.groupEnd();
+          }}
           onSubmit={e => {
             e.preventDefault();
             /* eslint-disable no-console */


### PR DESCRIPTION
When feeding <option> elements in the slot of dnn-select with a pre-selected item (selected = true) like when used on a form to edit something existing instead of doing something new; The underlying initialization logic was not setting the form level value upon initialization. This caused a discrepancy as it would display as valid but would prevent form submission because the form was not valid.

Also the form `onInvalid` event was not being fired making it even more confusing. This part was fixed in the dnn-button logic.