### PR TITLE
Added @typescript-eslint/utils to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22861,6 +22861,9 @@
         "typescript-debounce-decorator": "^0.0.18",
         "typescript-eslint": "^8.30.1",
         "vitest": "^3.1.1"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.30.1"
       }
     },
     "packages/stencil-library/node_modules/react": {

--- a/packages/stencil-library/eslint.config.ts
+++ b/packages/stencil-library/eslint.config.ts
@@ -34,6 +34,7 @@ export default (tseslint.config(
             "eslint-plugin/**/*",
             "**/*.spec.ts",
             ".storybook/**/*",
+            "storybook-static/**/*",
             "eslint.config.ts",
             "stencil.config.ts",
         ],

--- a/packages/stencil-library/package.json
+++ b/packages/stencil-library/package.json
@@ -98,5 +98,8 @@
   },
   "dependencies": {
     "jodit": "^4.6.2"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/utils": "^8.30.1"
   }
 }


### PR DESCRIPTION
This may be required for some consuming projects to be able to use our custom eslint-rules.