### PR TITLE
Adds support for marking components as internal

### DIFF
--- a/packages/react-library/lib/components/stencil-generated/components.ts
+++ b/packages/react-library/lib/components/stencil-generated/components.ts
@@ -17,7 +17,6 @@ import { DnnColorInput as DnnColorInputElement, defineCustomElement as defineDnn
 import { DnnColorPicker as DnnColorPickerElement, defineCustomElement as defineDnnColorPicker } from "@dnncommunity/dnn-elements/dist/components/dnn-color-picker.js";
 import { DnnContextMenu as DnnContextMenuElement, defineCustomElement as defineDnnContextMenu } from "@dnncommunity/dnn-elements/dist/components/dnn-context-menu.js";
 import { DnnDropzone as DnnDropzoneElement, defineCustomElement as defineDnnDropzone } from "@dnncommunity/dnn-elements/dist/components/dnn-dropzone.js";
-import { DnnExampleForm as DnnExampleFormElement, defineCustomElement as defineDnnExampleForm } from "@dnncommunity/dnn-elements/dist/components/dnn-example-form.js";
 import { DnnFieldset as DnnFieldsetElement, defineCustomElement as defineDnnFieldset } from "@dnncommunity/dnn-elements/dist/components/dnn-fieldset.js";
 import { DnnImageCropper as DnnImageCropperElement, defineCustomElement as defineDnnImageCropper } from "@dnncommunity/dnn-elements/dist/components/dnn-image-cropper.js";
 import { DnnInput as DnnInputElement, defineCustomElement as defineDnnInput } from "@dnncommunity/dnn-elements/dist/components/dnn-input.js";
@@ -161,17 +160,6 @@ export const DnnDropzone: StencilReactComponent<DnnDropzoneElement, DnnDropzoneE
     react: React,
     events: { onFilesSelected: 'filesSelected' } as DnnDropzoneEvents,
     defineCustomElement: defineDnnDropzone
-});
-
-export type DnnExampleFormEvents = NonNullable<unknown>;
-
-export const DnnExampleForm: StencilReactComponent<DnnExampleFormElement, DnnExampleFormEvents> = /*@__PURE__*/ createComponent<DnnExampleFormElement, DnnExampleFormEvents>({
-    tagName: 'dnn-example-form',
-    elementClass: DnnExampleFormElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as DnnExampleFormEvents,
-    defineCustomElement: defineDnnExampleForm
 });
 
 export type DnnFieldsetEvents = NonNullable<unknown>;

--- a/packages/stencil-library/custom-elements.json
+++ b/packages/stencil-library/custom-elements.json
@@ -780,7 +780,7 @@
           "kind": "class",
           "name": "dnn-context-menu.tsx",
           "tagName": "dnn-context-menu",
-          "description": "",
+          "description": "Can be used to display a context menu.\r\nThe contents of the menu as entirely up to the user.\r\nItems insile of `dnn-context-menu` that can be activated should have `role=\"menuitem\"` or similar for accessibility reasons.",
           "attributes": [
             {
               "name": "close-on-click",
@@ -924,24 +924,6 @@
               "description": "The color of the background when a file is dropping."
             }
           ],
-          "cssParts": []
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/examples/dnn-example-form/dnn-example-form.tsx",
-      "declarations": [
-        {
-          "kind": "class",
-          "name": "dnn-example-form.tsx",
-          "tagName": "dnn-example-form",
-          "description": "Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.",
-          "attributes": [],
-          "members": [],
-          "events": [],
-          "slots": [],
-          "cssProperties": [],
           "cssParts": []
         }
       ]
@@ -1243,7 +1225,7 @@
               "type": {
                 "text": "\"decimal\" | \"email\" | \"none\" | \"numeric\" | \"search\" | \"tel\" | \"text\" | \"url\" | undefined"
               },
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
               "required": false
             },
             {

--- a/packages/stencil-library/src/components.d.ts
+++ b/packages/stencil-library/src/components.d.ts
@@ -348,9 +348,6 @@ export namespace Components {
          */
         "resx"?: DropzoneResx;
     }
-    /**
-     * Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.
-     */
     interface DnnExampleForm {
     }
     /**
@@ -1104,9 +1101,6 @@ declare global {
         prototype: HTMLDnnDropzoneElement;
         new (): HTMLDnnDropzoneElement;
     };
-    /**
-     * Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.
-     */
     interface HTMLDnnExampleFormElement extends Components.DnnExampleForm, HTMLStencilElement {
     }
     var HTMLDnnExampleFormElement: {
@@ -1807,9 +1801,6 @@ declare namespace LocalJSX {
          */
         "resx"?: DropzoneResx;
     }
-    /**
-     * Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.
-     */
     interface DnnExampleForm {
     }
     /**
@@ -2589,9 +2580,6 @@ declare module "@stencil/core" {
             "dnn-color-picker": LocalJSX.IntrinsicElements["dnn-color-picker"] & JSXBase.HTMLAttributes<HTMLDnnColorPickerElement>;
             "dnn-context-menu": LocalJSX.IntrinsicElements["dnn-context-menu"] & JSXBase.HTMLAttributes<HTMLDnnContextMenuElement>;
             "dnn-dropzone": LocalJSX.IntrinsicElements["dnn-dropzone"] & JSXBase.HTMLAttributes<HTMLDnnDropzoneElement>;
-            /**
-             * Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.
-             */
             "dnn-example-form": LocalJSX.IntrinsicElements["dnn-example-form"] & JSXBase.HTMLAttributes<HTMLDnnExampleFormElement>;
             /**
              * A custom input component that wraps the html input element is a mobile friendly component that supports a label, some help text and other features.

--- a/packages/stencil-library/src/components/dnn-autocomplete/readme.md
+++ b/packages/stencil-library/src/components/dnn-autocomplete/readme.md
@@ -299,7 +299,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-button/readme.md
+++ b/packages/stencil-library/src/components/dnn-button/readme.md
@@ -85,7 +85,7 @@
 
  - [dnn-button](.)
  - [dnn-color-input](../dnn-color-input)
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
  - [dnn-permissions-grid](../dnn-permissions-grid)
 
 ### Depends on

--- a/packages/stencil-library/src/components/dnn-checkbox/readme.md
+++ b/packages/stencil-library/src/components/dnn-checkbox/readme.md
@@ -85,7 +85,7 @@ Type: `Promise<ValidityState>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
  - [dnn-permissions-grid](../dnn-permissions-grid)
 
 ### Graph

--- a/packages/stencil-library/src/components/dnn-color-input/readme.md
+++ b/packages/stencil-library/src/components/dnn-color-input/readme.md
@@ -58,7 +58,7 @@ A custom input component that allows previewing and changing a color value.
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-dropzone/readme.md
+++ b/packages/stencil-library/src/components/dnn-dropzone/readme.md
@@ -76,7 +76,7 @@ Notes:
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
  - [dnn-image-cropper](../dnn-image-cropper)
 
 ### Graph

--- a/packages/stencil-library/src/components/dnn-fieldset/readme.md
+++ b/packages/stencil-library/src/components/dnn-fieldset/readme.md
@@ -127,7 +127,7 @@ Type: `Promise<void>`
 
  - [dnn-autocomplete](../dnn-autocomplete)
  - [dnn-color-input](../dnn-color-input)
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
  - [dnn-input](../dnn-input)
  - [dnn-select](../dnn-select)
  - [dnn-textarea](../dnn-textarea)

--- a/packages/stencil-library/src/components/dnn-image-cropper/readme.md
+++ b/packages/stencil-library/src/components/dnn-image-cropper/readme.md
@@ -48,7 +48,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-input/readme.md
+++ b/packages/stencil-library/src/components/dnn-input/readme.md
@@ -95,7 +95,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-monaco-editor/readme.md
+++ b/packages/stencil-library/src/components/dnn-monaco-editor/readme.md
@@ -64,7 +64,7 @@
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Graph
 ```mermaid

--- a/packages/stencil-library/src/components/dnn-richtext/readme.md
+++ b/packages/stencil-library/src/components/dnn-richtext/readme.md
@@ -28,7 +28,7 @@
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Graph
 ```mermaid

--- a/packages/stencil-library/src/components/dnn-select/readme.md
+++ b/packages/stencil-library/src/components/dnn-select/readme.md
@@ -54,7 +54,7 @@ Type: `Promise<ValidityState>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-textarea/readme.md
+++ b/packages/stencil-library/src/components/dnn-textarea/readme.md
@@ -79,7 +79,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Depends on
 

--- a/packages/stencil-library/src/components/dnn-toggle/readme.md
+++ b/packages/stencil-library/src/components/dnn-toggle/readme.md
@@ -67,7 +67,7 @@
 
 ### Used by
 
- - [dnn-example-form](../examples/dnn-example-form)
+ - dnn-example-form
 
 ### Graph
 ```mermaid

--- a/packages/stencil-library/src/components/examples/dnn-example-form/dnn-example-form.tsx
+++ b/packages/stencil-library/src/components/examples/dnn-example-form/dnn-example-form.tsx
@@ -1,7 +1,10 @@
 import { Component, Host, h, State } from '@stencil/core';
 import { DnnAutocompleteSuggestion } from '../../dnn-autocomplete/types';
 
-/** Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package. */
+/**
+* @internal
+ * Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package.
+ */
 @Component({
   tag: 'dnn-example-form',
   styleUrl: 'dnn-example-form.scss',

--- a/packages/stencil-library/stencil.config.ts
+++ b/packages/stencil-library/stencil.config.ts
@@ -126,7 +126,10 @@ export const config: Config = {
     },
     {
       type: "docs-custom",
-      generator: generateCustomElementsJson,
+      generator: (docsData) => generateCustomElementsJson({
+        ...docsData,
+        components: docsData.components.filter(c => !c.docsTags.some(t => t.name === 'internal')),
+      }),
     },
     {
       type: "docs-vscode",

--- a/packages/stencil-library/vscode-data.json
+++ b/packages/stencil-library/vscode-data.json
@@ -298,7 +298,7 @@
       "name": "dnn-context-menu",
       "description": {
         "kind": "markdown",
-        "value": ""
+        "value": "Can be used to display a context menu.\r\nThe contents of the menu as entirely up to the user.\r\nItems insile of `dnn-context-menu` that can be activated should have `role=\"menuitem\"` or similar for accessibility reasons."
       },
       "attributes": [
         {
@@ -335,14 +335,6 @@
           "description": "The name of the field when used in a form."
         }
       ]
-    },
-    {
-      "name": "dnn-example-form",
-      "description": {
-        "kind": "markdown",
-        "value": "Do not use this component in production, it is meant for testing purposes only and is not distributed in the production package."
-      },
-      "attributes": []
     },
     {
       "name": "dnn-fieldset",
@@ -459,7 +451,7 @@
         },
         {
           "name": "inputmode",
-          "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+          "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
           "values": [
             {
               "name": "decimal"


### PR DESCRIPTION
We sometimes need to create components that we don't want consumers to use directly:
- The component is an example
- The component is only used internally as part of a larger complex component

With this change we can exclude such components with `@internal` jsdoc attribute which will skip it from types and vscode docs to reduce their discoverability.